### PR TITLE
APK splits based on ABI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,15 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    splits {
+        abi {
+            enable true
+
+            reset()
+            include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+        }
+    }
 }
 
 def buildVersionName(versionMajor, versionMinor, versionPatch) {


### PR DESCRIPTION
# DO NOT MERGE

Basically a purpose of this change is decreasing the APK size downloaded from Google Play. It (probably) will require to tweak the build script even more. Take a look at the `Things to read` section below.

## Stats

#### Before
```
$ ls -lah build/outputs/apk
total 75M
drwxr-xr-x 2 user user 4.0K Feb 12 16:17 .
drwxr-xr-x 3 user user 4.0K Feb 12 16:17 ..
-rw-r--r-- 1 user user  38M Feb 12 16:17 amahi-debug.apk
-rw-r--r-- 1 user user  38M Feb 12 16:17 amahi-debug-unaligned.apk
-rw-r--r-- 1 user user 6.9K Feb 12 16:17 manifest-merger-debug-report.txt
```

### After

```
$ ls -lah build/outputs/apk
total 81M
drwxr-xr-x 2 user user 4.0K Feb 12 16:23 .
drwxr-xr-x 3 user user 4.0K Feb 12 16:23 ..
-rw-r--r-- 1 user user  11M Feb 12 16:23 amahi-arm64-v8a-debug.apk
-rw-r--r-- 1 user user  11M Feb 12 16:23 amahi-arm64-v8a-debug-unaligned.apk
-rw-r--r-- 1 user user 9.2M Feb 12 16:23 amahi-armeabi-v7a-debug.apk
-rw-r--r-- 1 user user 9.2M Feb 12 16:23 amahi-armeabi-v7a-debug-unaligned.apk
-rw-r--r-- 1 user user  11M Feb 12 16:23 amahi-x86_64-debug.apk
-rw-r--r-- 1 user user  11M Feb 12 16:23 amahi-x86_64-debug-unaligned.apk
-rw-r--r-- 1 user user  11M Feb 12 16:23 amahi-x86-debug.apk
-rw-r--r-- 1 user user  11M Feb 12 16:23 amahi-x86-debug-unaligned.apk
-rw-r--r-- 1 user user 6.9K Feb 12 16:23 manifest-merger-debug-report.txt
```

## Things to read

* [APK splits](http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits)
* [Multiple APK](http://developer.android.com/google/play/publishing/multiple-apks.html)