### PR TITLE
Move Crashlytics keys into a different file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Gradle, Android SDK and project dependencies will be downloaded automatically.
   client.id = ID
   client.secret = SECRET
   ```
+  
+  ```
+  $ vim fabric.properties
+  ```
+  ```
+  apiKey=YOUR_API_KEY
+  apiSecret=YOUR_API_SECRET (Optional)
+  ```
+
 
 3. Build the application.
 

--- a/fabric.properties
+++ b/fabric.properties
@@ -1,0 +1,2 @@
+apiKey=d7b65346d3cf0028328f006bff447501d70f8996
+#apiSecret=

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -142,11 +142,6 @@
 
 		</receiver>
 
-		<meta-data
-			android:name="com.crashlytics.ApiKey"
-			android:value="d7b65346d3cf0028328f006bff447501d70f8996"/>
-			/>
-
 	</application>
 
 </manifest>


### PR DESCRIPTION
This seems enough but there is one issue I'm not quite sure how to tackle yet.

It seems that there is only one apiKey used at this time but there are two flavors. Is the same apiKey used for both flavors? (Beta and Release)