### PR TITLE
deprecated ActionBarDrawerToggle updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ dependencies {
 
     compile "com.android.support:support-v4:25.1.1"
     compile "com.android.support:support-v13:25.1.1"
+    compile 'com.android.support:appcompat-v7:25.1.1'
     compile "com.github.dmytrodanylyk.android-process-button:library:1.0.4"
     compile "com.jakewharton.byteunits:byteunits:0.9.1"
     compile "com.jakewharton.timber:timber:4.5.1"

--- a/src/main/java/org/amahi/anywhere/activity/NavigationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/NavigationActivity.java
@@ -25,8 +25,8 @@ import android.app.Fragment;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarDrawerToggle;
 import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
@@ -118,12 +118,12 @@ public class NavigationActivity extends Activity implements DrawerLayout.DrawerL
 	private void setUpNavigationDrawer() {
 		this.navigationDrawerToggle = buildNavigationDrawerToggle();
 
-		getDrawer().setDrawerListener(this);
+		getDrawer().addDrawerListener(this);
 		getDrawer().setDrawerShadow(R.drawable.bg_shadow_drawer, Gravity.START);
 	}
 
 	private ActionBarDrawerToggle buildNavigationDrawerToggle() {
-		return new ActionBarDrawerToggle(this,getDrawer(), R.drawable.ic_ic_ham_menu,R.string.menu_navigation_open,R.string.menu_navigation_close);
+		return new ActionBarDrawerToggle(this,getDrawer(),R.string.menu_navigation_open,R.string.menu_navigation_close);
 	}
 
 	private DrawerLayout getDrawer() {


### PR DESCRIPTION
As described in #46, use of _android.support.v4.app.ActionBarDrawerToggle_ is deprecated hence I have updated it with _android.support.v7.app.ActionBarDrawerToggle_ along with its methods as well. #46 