### PR TITLE
Adds swipeRefreshLayout in side nav bar, fixes #60

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/NavigationFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/NavigationFragment.java
@@ -31,6 +31,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -74,7 +75,8 @@ import javax.inject.Inject;
 public class NavigationFragment extends Fragment implements AccountManagerCallback<Bundle>,
 	OnAccountsUpdateListener,
 	AdapterView.OnItemSelectedListener,
-	AdapterView.OnItemClickListener
+	AdapterView.OnItemClickListener,
+	SwipeRefreshLayout.OnRefreshListener
 {
 	private static final class State
 	{
@@ -104,6 +106,8 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 		setUpSettingsMenu();
 
 		setUpAuthenticationListener();
+
+		setUpContentRefreshing();
 
 		setUpServers(savedInstanceState);
 	}
@@ -135,6 +139,24 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 		}
 	}
 
+	private void setUpContentRefreshing() {
+		SwipeRefreshLayout refreshLayout = getRefreshLayout();
+
+		refreshLayout.setColorSchemeResources(
+				android.R.color.holo_blue_light,
+				android.R.color.holo_orange_light,
+				android.R.color.holo_green_light,
+				android.R.color.holo_red_light);
+
+		refreshLayout.setOnRefreshListener(this);
+	}
+
+	@Override
+	public void onRefresh() {
+		ViewDirector.of(this, R.id.animator_content).show(R.id.empty_view);
+		setUpServers(new Bundle());
+	}
+
 	private List<Account> getAccounts() {
 		return Arrays.asList(getAccountManager().getAccountsByType(AmahiAccount.TYPE));
 	}
@@ -163,9 +185,7 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 			}
 		} catch (OperationCanceledException e) {
 			tearDownActivity();
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		} catch (AuthenticatorException e) {
+		} catch (IOException | AuthenticatorException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -175,13 +195,15 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 	}
 
 	private void setUpServers(Bundle state) {
+		getRefreshLayout().setRefreshing(true);
 		setUpServersAdapter();
 		setUpServersContent(state);
 		setUpServersListener();
 	}
 
 	private void setUpServersAdapter() {
-		getServersSpinner().setAdapter(new ServersAdapter(getActivity()));
+		if (!areServersLoaded())
+			getServersSpinner().setAdapter(new ServersAdapter(getActivity()));
 	}
 
 	private Spinner getServersSpinner() {
@@ -230,6 +252,7 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 	}
 
 	private void showContent() {
+		getRefreshLayout().setRefreshing(false);
 		ViewDirector.of(this, R.id.animator_content).show(R.id.layout_content);
 	}
 
@@ -258,6 +281,10 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 		setUpNavigation();
 
 		showContent();
+	}
+
+	private SwipeRefreshLayout getRefreshLayout() {
+		return (SwipeRefreshLayout) getView().findViewById(R.id.layout_refresh);
 	}
 
 	private void setUpNavigation() {
@@ -308,6 +335,7 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
 	}
 
 	private void showError() {
+		getRefreshLayout().setRefreshing(false);
 		ViewDirector.of(this, R.id.animator_content).show(R.id.layout_error);
 	}
 

--- a/src/main/res/layout/fragment_navigation.xml
+++ b/src/main/res/layout/fragment_navigation.xml
@@ -17,67 +17,72 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
   -->
+<android.support.v4.widget.SwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout_refresh"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-<ViewAnimator xmlns:android="http://schemas.android.com/apk/res/android"
-	android:id="@+id/animator_content"
-	android:inAnimation="@android:anim/fade_in"
-	android:outAnimation="@android:anim/fade_out"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent">
+    <ViewAnimator
+        android:id="@+id/animator_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:inAnimation="@android:anim/fade_in"
+        android:outAnimation="@android:anim/fade_out">
 
-	<ProgressBar
-		android:id="@+id/progress_content"
-		android:layout_gravity="center"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"/>
+        <View
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
 
-	<LinearLayout
-		android:id="@+id/layout_content"
-		android:orientation="vertical"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent">
+        <LinearLayout
+            android:id="@+id/layout_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-		<Spinner
-			android:id="@+id/spinner_servers"
-			android:layout_marginLeft="8dp"
-			android:layout_marginRight="8dp"
-			android:layout_width="match_parent"
-			android:layout_height="64dp"/>
+            <Spinner
+                android:id="@+id/spinner_servers"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"/>
 
-		<ListView
-			android:id="@+id/list_navigation"
-			android:choiceMode="singleChoice"
-			android:divider="@null"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"/>
+            <ListView
+                android:id="@+id/list_navigation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:choiceMode="singleChoice"
+                android:divider="@null"/>
 
-	</LinearLayout>
+        </LinearLayout>
 
-	<LinearLayout
-		android:id="@+id/layout_error"
-		android:orientation="vertical"
-		android:layout_gravity="center"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content">
+        <LinearLayout
+            android:id="@+id/layout_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical">
 
-		<TextView
-			android:text="@string/message_error_connection"
-			android:textSize="@dimen/text_medium"
-			android:textStyle="bold"
-			android:gravity="center_horizontal"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/message_error_connection"
+                android:textSize="@dimen/text_medium"
+                android:textStyle="bold"/>
 
-		<Space
-			android:layout_width="match_parent"
-			android:layout_height="8dp"/>
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="8dp"/>
 
-		<TextView
-			android:text="@string/message_notice_check_settings"
-			android:gravity="center_horizontal"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/message_notice_check_settings"/>
 
-	</LinearLayout>
+        </LinearLayout>
 
-</ViewAnimator>
+    </ViewAnimator>
+</android.support.v4.widget.SwipeRefreshLayout>


### PR DESCRIPTION
A swipe down to refresh layout has been implemented in the side navigation bar (the one which shows the spinner for hda selection). It will ease the process of refreshing the server list as discussed in #60.