### PR TITLE
Add IME_ACTION_GO listener on Password EditText in AuthenticationActivity

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -30,7 +30,9 @@ import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.method.LinkMovementMethod;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -115,6 +117,17 @@ public class AuthenticationActivity extends AccountAuthenticatorActivity impleme
 	private void setUpAuthenticationTextListener() {
 		getUsernameEdit().addTextChangedListener(this);
 		getPasswordEdit().addTextChangedListener(this);
+		getPasswordEdit().setOnEditorActionListener(new EditText.OnEditorActionListener() {
+			@Override
+			public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+				boolean handled = false;
+				if (actionId == EditorInfo.IME_ACTION_GO) {
+					onClick(getAuthenticationButton());
+					handled = true;
+				}
+				return handled;
+			}
+		});
 	}
 
 	@Override

--- a/src/main/res/layout-land/layout_authentication.xml
+++ b/src/main/res/layout-land/layout_authentication.xml
@@ -58,7 +58,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/hint_username"
-                android:inputType="text" />
+                android:inputType="text"
+                android:maxLines="1" />
 
         </android.support.design.widget.TextInputLayout>
 
@@ -77,6 +78,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:hint="@string/hint_password"
+                android:imeOptions="actionGo"
                 android:inputType="textPassword" />
 
         </android.support.design.widget.TextInputLayout>

--- a/src/main/res/layout/layout_authentication.xml
+++ b/src/main/res/layout/layout_authentication.xml
@@ -49,7 +49,8 @@
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:hint="@string/hint_username"
-			android:inputType="text"/>
+			android:inputType="text"
+			android:maxLines="1" />
 
 	</android.support.design.widget.TextInputLayout>
 
@@ -68,6 +69,7 @@
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:hint="@string/hint_password"
+			android:imeOptions="actionGo"
 			android:inputType="textPassword"/>
 
 	</android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
Clicking Go in keyboard after entering the password will call "SIGN IN" button's onClick listener.
Previously, it hid the keyboard and then the user had to click the "SIGN IN" button.