### PR TITLE
Move v21 Themes to fix crash in older devices

### DIFF
--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -1,38 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<style name="Theme.Amahi" parent="@style/Theme.AppCompat">
-		<item name="android:actionBarStyle">@style/Theme.Amahi.ActionBar</item>
-		<item name="android:windowBackground">@color/background_primary</item>
-		<item name="android:colorAccent">@color/accent_material_dark</item>
-		<item name="android:textColorPrimaryInverse">@color/primary_text_material_light</item>
-		<!--Adding Support for the Support Library-->
-		<item name="actionBarStyle">@style/Theme.Amahi.ActionBar</item>
-		<item name="colorAccent">@color/accent_material_dark</item>
-	</style>
 
-	<style name="Theme.Amahi.Fullscreen.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
-		<item name="android:background">@color/background_transparent_primary</item>
-		<item name="android:displayOptions">showHome|homeAsUp|showTitle</item>
-		<!--Adding Support for the Support Library-->
-		<item name="background">@color/background_transparent_primary</item>
-		<item name="displayOptions">showHome|homeAsUp|showTitle</item>
-	</style>
+    <style name="Theme.Amahi" parent="@style/Theme.AppCompat">
+        <item name="android:actionBarStyle">@style/Theme.Amahi.ActionBar</item>
+        <item name="android:windowBackground">@color/background_primary</item>
+        <item name="android:colorAccent">@color/accent_material_dark</item>
+        <item name="android:textColorPrimaryInverse">@color/primary_text_material_light</item>
+        <!--Adding Support for the Support Library-->
+        <item name="actionBarStyle">@style/Theme.Amahi.ActionBar</item>
+        <item name="colorAccent">@color/accent_material_dark</item>
+    </style>
 
-	<style name="Theme.Amahi.Fullscreen" parent="@style/Theme.AppCompat">
-		<item name="android:actionBarStyle">@style/Theme.Amahi.Fullscreen.ActionBar</item>
-		<item name="android:windowActionBarOverlay">true</item>
-		<item name="android:windowBackground">@android:color/black</item>
-		<item name="android:windowContentOverlay">@null</item>
-		<!--Adding Support for the Support Library-->
-		<item name="actionBarStyle">@style/Theme.Amahi.Fullscreen.ActionBar</item>
-		<item name="windowActionBarOverlay">true</item>
-	</style>
-
-	<style name="Theme.Amahi.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
-		<item name="android:background">@drawable/bg_action_bar</item>
-		<item name="android:displayOptions">showHome|homeAsUp|showTitle</item>
-		<!--Adding Support for the Support Library-->
-		<item name="background">@drawable/bg_action_bar</item>
-		<item name="displayOptions">showHome|homeAsUp|showTitle</item>
-	</style>
+    <style name="Theme.Amahi.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
+        <item name="android:background">@drawable/bg_action_bar</item>
+        <item name="android:displayOptions">showHome|homeAsUp|showTitle</item>
+        <!--Adding Support for the Support Library-->
+        <item name="background">@drawable/bg_action_bar</item>
+        <item name="displayOptions">showHome|homeAsUp|showTitle</item>
+    </style>
 </resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -19,6 +19,41 @@
   -->
 
 <resources>
+    <style name="Theme.Amahi" parent="@style/Theme.AppCompat">
+        <item name="android:actionBarStyle">@style/Theme.Amahi.ActionBar</item>
+        <item name="android:windowBackground">@color/background_primary</item>
+        <item name="android:textColorPrimaryInverse">@color/primary_text_material_light</item>
+        <!--Adding Support for the Support Library-->
+        <item name="actionBarStyle">@style/Theme.Amahi.ActionBar</item>
+        <item name="colorAccent">@color/accent_material_dark</item>
+    </style>
+
+    <style name="Theme.Amahi.Fullscreen.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
+        <item name="android:background">@color/background_transparent_primary</item>
+        <item name="android:displayOptions">showHome|homeAsUp|showTitle</item>
+        <!--Adding Support for the Support Library-->
+        <item name="background">@color/background_transparent_primary</item>
+        <item name="displayOptions">showHome|homeAsUp|showTitle</item>
+    </style>
+
+    <style name="Theme.Amahi.Fullscreen" parent="@style/Theme.AppCompat">
+        <item name="android:actionBarStyle">@style/Theme.Amahi.Fullscreen.ActionBar</item>
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <!--Adding Support for the Support Library-->
+        <item name="actionBarStyle">@style/Theme.Amahi.Fullscreen.ActionBar</item>
+        <item name="windowActionBarOverlay">true</item>
+    </style>
+
+    <style name="Theme.Amahi.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
+        <item name="android:background">@drawable/bg_action_bar</item>
+        <item name="android:displayOptions">showHome|homeAsUp|showTitle</item>
+        <!--Adding Support for the Support Library-->
+        <item name="background">@drawable/bg_action_bar</item>
+        <item name="displayOptions">showHome|homeAsUp|showTitle</item>
+    </style>
+
     <style name="Theme.Amahi.Authentication" parent="Theme.AppCompat">
         <item name="android:windowNoTitle">true</item>
         <item name="android:actionBarStyle">@style/Theme.Amahi.ActionBar</item>


### PR DESCRIPTION
Since the themes were set in v21 resource folder, the app crashed in devices older than v21.