### PR TITLE
Replace Fragments with Support Fragments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     compile "com.android.support:recyclerview-v7:${SUPPORT_LIBRARY_VERSION}"
     compile "com.android.support:appcompat-v7:${SUPPORT_LIBRARY_VERSION}"
     compile "com.android.support:design:${SUPPORT_LIBRARY_VERSION}"
+    compile "com.android.support:preference-v7:${SUPPORT_LIBRARY_VERSION}"
     compile "com.github.dmytrodanylyk.android-process-button:library:1.0.4"
     compile "com.jakewharton.byteunits:byteunits:0.9.1"
     compile "com.jakewharton.timber:timber:4.5.1"

--- a/src/main/java/org/amahi/anywhere/activity/NavigationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/NavigationActivity.java
@@ -19,7 +19,7 @@
 
 package org.amahi.anywhere.activity;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;

--- a/src/main/java/org/amahi/anywhere/activity/ServerFileImageActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFileImageActivity.java
@@ -127,7 +127,7 @@ public class ServerFileImageActivity extends AppCompatActivity implements ViewPa
 	}
 
 	private void setUpImageAdapter() {
-		getImagePager().setAdapter(new ServerFilesImagePagerAdapter(getFragmentManager(), getShare(), getImageFiles()));
+		getImagePager().setAdapter(new ServerFilesImagePagerAdapter(getSupportFragmentManager(), getShare(), getImageFiles()));
 	}
 
 	private ClickableViewPager getImagePager() {

--- a/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
@@ -20,7 +20,7 @@
 package org.amahi.anywhere.activity;
 
 import android.app.DialogFragment;
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;

--- a/src/main/java/org/amahi/anywhere/activity/SettingsActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/SettingsActivity.java
@@ -19,7 +19,7 @@
 
 package org.amahi.anywhere.activity;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;

--- a/src/main/java/org/amahi/anywhere/adapter/ServerFilesImagePagerAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerFilesImagePagerAdapter.java
@@ -19,9 +19,9 @@
 
 package org.amahi.anywhere.adapter;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.support.v13.app.FragmentStatePagerAdapter;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
 
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;

--- a/src/main/java/org/amahi/anywhere/fragment/GooglePlaySearchFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/GooglePlaySearchFragment.java
@@ -19,7 +19,7 @@
 
 package org.amahi.anywhere.fragment;
 
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;

--- a/src/main/java/org/amahi/anywhere/fragment/NavigationFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/NavigationFragment.java
@@ -26,7 +26,7 @@ import android.accounts.AccountManagerFuture;
 import android.accounts.AuthenticatorException;
 import android.accounts.OnAccountsUpdateListener;
 import android.accounts.OperationCanceledException;
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Parcelable;

--- a/src/main/java/org/amahi/anywhere/fragment/ServerAppsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerAppsFragment.java
@@ -19,7 +19,7 @@
 
 package org.amahi.anywhere.fragment;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v7.widget.DividerItemDecoration;

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFileImageFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFileImageFragment.java
@@ -19,7 +19,7 @@
 
 package org.amahi.anywhere.fragment;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -20,7 +20,7 @@
 package org.amahi.anywhere.fragment;
 
 import android.Manifest;
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.pm.PackageManager;

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -19,7 +19,7 @@
 
 package org.amahi.anywhere.fragment;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v7.widget.DividerItemDecoration;

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -26,10 +26,9 @@ import android.accounts.AccountManagerFuture;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.ListPreference;
-import android.preference.Preference;
-import android.preference.PreferenceFragment;
-import android.util.Log;
+import android.support.v7.preference.ListPreference;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceFragmentCompat;
 import android.widget.Toast;
 
 import org.amahi.anywhere.AmahiApplication;
@@ -49,7 +48,7 @@ import javax.inject.Inject;
 /**
  * Settings fragment. Shows application's settings.
  */
-public class SettingsFragment extends PreferenceFragment implements Preference.OnPreferenceClickListener,
+public class SettingsFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceClickListener,
 	SharedPreferences.OnSharedPreferenceChangeListener,
 	AccountManagerCallback<Boolean>
 {
@@ -57,9 +56,7 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
 	ServerClient serverClient;
 
 	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
+	public void onCreatePreferences(Bundle bundle, String s) {
 		setUpInjections();
 
 		setUpSettings();
@@ -80,20 +77,19 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
 	}
 
 	private void setUpSettingsSummary() {
-		ListPreference serverConnection = getPreference(R.string.preference_key_server_connection);
+		ListPreference serverConnection = (ListPreference) getPreference(R.string.preference_key_server_connection);
 		Preference applicationVersion = getPreference(R.string.preference_key_about_version);
 
 		serverConnection.setSummary(getServerConnectionSummary());
 		applicationVersion.setSummary(getApplicationVersionSummary());
 	}
 
-	@SuppressWarnings("unchecked")
-	private <T extends Preference> T getPreference(int settingId) {
-		return (T) findPreference(getString(settingId));
+	private Preference getPreference(int settingId) {
+		return findPreference(getString(settingId));
 	}
 
 	private String getServerConnectionSummary() {
-		ListPreference serverConnection = getPreference(R.string.preference_key_server_connection);
+		ListPreference serverConnection = (ListPreference) getPreference(R.string.preference_key_server_connection);
 
 		return String.format("%s", serverConnection.getEntry());
 	}
@@ -241,7 +237,7 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
 	}
 
 	private ApiConnection getServerConnection() {
-		ListPreference serverConnection = getPreference(R.string.preference_key_server_connection);
+		ListPreference serverConnection = (ListPreference) getPreference(R.string.preference_key_server_connection);
 
 		if (serverConnection.getValue().equals(getString(R.string.preference_key_server_connection_auto))) {
 			return ApiConnection.AUTO;

--- a/src/main/java/org/amahi/anywhere/util/Fragments.java
+++ b/src/main/java/org/amahi/anywhere/util/Fragments.java
@@ -19,10 +19,10 @@
 
 package org.amahi.anywhere.util;
 
-import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 
 import org.amahi.anywhere.fragment.NavigationFragment;
 import org.amahi.anywhere.fragment.ServerAppsFragment;
@@ -91,7 +91,7 @@ public final class Fragments
 			return fileFragment;
 		}
 
-		public static Fragment buildSettingsFragment() {
+		public static android.support.v4.app.Fragment buildSettingsFragment() {
 			return new SettingsFragment();
 		}
 	}
@@ -99,13 +99,15 @@ public final class Fragments
 	public static final class Operator
 	{
 		private final FragmentManager fragmentManager;
+		private final android.support.v4.app.FragmentManager supportFragmentManager;
 
-		public static Operator at(Activity activity) {
+		public static Operator at(AppCompatActivity activity) {
 			return new Operator(activity);
 		}
 
-		private Operator(Activity activity) {
+		private Operator(AppCompatActivity activity) {
 			this.fragmentManager = activity.getFragmentManager();
+			this.supportFragmentManager = activity.getSupportFragmentManager();
 		}
 
 		public void set(Fragment fragment, int fragmentContainerId) {
@@ -117,6 +119,17 @@ public final class Fragments
 				.beginTransaction()
 				.add(fragmentContainerId, fragment)
 				.commit();
+		}
+
+		public void set(android.support.v4.app.Fragment fragment, int fragmentContainerId) {
+			if (isSet(fragmentContainerId)) {
+				return;
+			}
+
+			supportFragmentManager
+					.beginTransaction()
+					.add(fragmentContainerId, fragment)
+					.commit();
 		}
 
 		private boolean isSet(int fragmentContainerId) {

--- a/src/main/java/org/amahi/anywhere/util/Fragments.java
+++ b/src/main/java/org/amahi/anywhere/util/Fragments.java
@@ -19,8 +19,8 @@
 
 package org.amahi.anywhere.util;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -99,15 +99,13 @@ public final class Fragments
 	public static final class Operator
 	{
 		private final FragmentManager fragmentManager;
-		private final android.support.v4.app.FragmentManager supportFragmentManager;
 
 		public static Operator at(AppCompatActivity activity) {
 			return new Operator(activity);
 		}
 
 		private Operator(AppCompatActivity activity) {
-			this.fragmentManager = activity.getFragmentManager();
-			this.supportFragmentManager = activity.getSupportFragmentManager();
+			this.fragmentManager = activity.getSupportFragmentManager();
 		}
 
 		public void set(Fragment fragment, int fragmentContainerId) {
@@ -119,17 +117,6 @@ public final class Fragments
 				.beginTransaction()
 				.add(fragmentContainerId, fragment)
 				.commit();
-		}
-
-		public void set(android.support.v4.app.Fragment fragment, int fragmentContainerId) {
-			if (isSet(fragmentContainerId)) {
-				return;
-			}
-
-			supportFragmentManager
-					.beginTransaction()
-					.add(fragmentContainerId, fragment)
-					.commit();
 		}
 
 		private boolean isSet(int fragmentContainerId) {

--- a/src/main/java/org/amahi/anywhere/util/ViewDirector.java
+++ b/src/main/java/org/amahi/anywhere/util/ViewDirector.java
@@ -20,7 +20,7 @@
 package org.amahi.anywhere.util;
 
 import android.app.Activity;
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.view.View;
 import android.widget.ViewAnimator;
 

--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -9,6 +9,7 @@
         <!--Adding Support for the Support Library-->
         <item name="actionBarStyle">@style/Theme.Amahi.ActionBar</item>
         <item name="colorAccent">@color/accent_material_dark</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
     <style name="Theme.Amahi.ActionBar" parent="@style/Widget.AppCompat.ActionBar">

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -26,6 +26,7 @@
         <!--Adding Support for the Support Library-->
         <item name="actionBarStyle">@style/Theme.Amahi.ActionBar</item>
         <item name="colorAccent">@color/accent_material_dark</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
     <style name="Theme.Amahi.Fullscreen.ActionBar" parent="@style/Widget.AppCompat.ActionBar">

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -18,45 +18,45 @@
   ~ along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
   -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<PreferenceCategory android:title="@string/preference_category_account">
+	<android.support.v7.preference.PreferenceCategory android:title="@string/preference_category_account">
 
 		<Preference
 			android:key="@string/preference_key_account_sign_out"
 			android:title="@string/preference_title_account_sign_out"/>
 
-	</PreferenceCategory>
+	</android.support.v7.preference.PreferenceCategory>
 
-	<PreferenceCategory android:title="@string/preference_category_settings">
+	<android.support.v7.preference.PreferenceCategory android:title="@string/preference_category_settings">
 
-		<ListPreference
+		<android.support.v7.preference.ListPreference
 			android:key="@string/preference_key_server_connection"
 			android:title="@string/preference_title_server_connection"
 			android:entries="@array/preference_entries_server_connection"
 			android:entryValues="@array/preference_entries_keys_server_connection"
 			android:defaultValue="@string/preference_key_server_connection_auto"/>
 
-	</PreferenceCategory>
+	</android.support.v7.preference.PreferenceCategory>
 
-	<PreferenceCategory android:title="@string/preference_category_about">
+	<android.support.v7.preference.PreferenceCategory android:title="@string/preference_category_about">
 
-		<Preference
+		<android.support.v7.preference.Preference
 			android:key="@string/preference_key_about_version"
 			android:title="@string/preference_title_about_version"/>
 
-		<Preference
+		<android.support.v7.preference.Preference
 			android:key="@string/preference_key_about_feedback"
 			android:title="@string/preference_title_about_feedback"/>
 
-		<Preference
+		<android.support.v7.preference.Preference
 			android:key="@string/preference_key_about_rating"
 			android:title="@string/preference_title_about_rating"/>
 
-		<Preference
+		<android.support.v7.preference.Preference
 			android:key="@string/preference_key_tell_a_friend"
 			android:title="@string/preference_title_tell_a_friend"/>
 
-	</PreferenceCategory>
+	</android.support.v7.preference.PreferenceCategory>
 
-</PreferenceScreen>
+</android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
This is similar to #96 in which Activity was replaced with AppCompatActivity.
This will bring Material Design to older devices.

AlertDialog and Support v7 AlertDialog
![alertdialog](https://cloud.githubusercontent.com/assets/3854934/24219631/815da174-0f6d-11e7-934c-a2fd22462a33.jpg)

ListPreference and Support v7 ListPreference
![listpreference](https://cloud.githubusercontent.com/assets/3854934/24219633/815f254e-0f6d-11e7-9982-8be54e42f6c7.jpg)

Preference Fragment, Support v7 Preference and Support v14 Preference
![preferencefragment](https://cloud.githubusercontent.com/assets/3854934/24219632/815e7dd8-0f6d-11e7-98b8-ca8b13a533c9.jpg)

As shown in the image, Support v14 Preference has padding issues and Google hasn't fixed it yet.
I have used v7 Preference, for the time being, which is not material design. 
[Issue 233934:	preference-v14 padding/margin wrong on KitKat and Jelly Bean](https://code.google.com/p/android/issues/detail?id=233934)
[Issue 213297:	Preference support library v24.0.0 wrong padding on API levels below 21](https://code.google.com/p/android/issues/detail?id=213297)