### PR TITLE
Remove duplicate api.properties entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,8 @@ build/
 .idea/
 *.iml
 
-# Android SDK
-
+# Local configuration file (sdk path, etc)
 local.properties
-
-# API
-
-api.properties
 
 # Crashlytics
 
@@ -22,6 +17,7 @@ crashlytics.properties
 crashlytics-build.properties
 com_crashlytics_export_strings.xml
 fabric.properties
+
 # Key
 
 signing.properties


### PR DESCRIPTION
`api.properties` entry was defined more than once.