### PR TITLE
Add Ripple Effect for ListView Items

### DIFF
--- a/src/main/res/layout/view_navigation_item.xml
+++ b/src/main/res/layout/view_navigation_item.xml
@@ -23,6 +23,7 @@
 	android:maxLines="1"
 	android:textSize="@dimen/text_medium"
 	android:background="?android:attr/activatedBackgroundIndicator"
+	android:foreground="?android:attr/selectableItemBackgroundBorderless"
 	android:gravity="center_vertical"
 	android:padding="16dp"
 	android:layout_width="match_parent"

--- a/src/main/res/layout/view_server_file_item.xml
+++ b/src/main/res/layout/view_server_file_item.xml
@@ -20,6 +20,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:background="?android:attr/activatedBackgroundIndicator"
+	android:foreground="?android:attr/selectableItemBackgroundBorderless"
 	android:orientation="horizontal"
        android:layout_width="match_parent"
        android:padding="8dp"

--- a/src/main/res/layout/view_server_file_metadata_item.xml
+++ b/src/main/res/layout/view_server_file_metadata_item.xml
@@ -19,7 +19,8 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:foreground="?android:attr/activatedBackgroundIndicator"
+	android:background="?android:attr/activatedBackgroundIndicator"
+	android:foreground="?android:attr/selectableItemBackgroundBorderless"
 	android:layout_width="157dp"
 	android:layout_height="250dp">
 

--- a/src/main/res/layout/view_server_share_item.xml
+++ b/src/main/res/layout/view_server_share_item.xml
@@ -23,6 +23,7 @@
 	android:maxLines="1"
 	android:textSize="@dimen/text_medium"
 	android:background="?android:attr/activatedBackgroundIndicator"
+	android:foreground="?android:attr/selectableItemBackgroundBorderless"
 	android:gravity="center_vertical"
 	android:padding="8dp"
 	android:layout_width="match_parent"


### PR DESCRIPTION
This does not apply to pre-Lollipop as given in [AppCompat v21 — Material Design for Pre-Lollipop Devices!](https://android-developers.googleblog.com/2014/10/appcompat-v21-material-design-for-pre.html)
```
Why are there no ripples on pre-Lollipop?
A lot of what allows RippleDrawable to run smoothly is Android 5.0’s new RenderThread. 
To optimize for performance on previous versions of Android, we've left RippleDrawable out for now.
```

![ripple](https://cloud.githubusercontent.com/assets/3854934/24384699/6f689ac2-1383-11e7-8685-fe764133e8d0.gif)