### PR TITLE
Replace Picasso by Glide

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'io.fabric.tools:gradle:1.22.1'
     }
 }
@@ -114,7 +114,7 @@ dependencies {
     compile "com.jakewharton.timber:timber:4.5.1"
     compile "com.squareup.dagger:dagger:1.2.5"
     compile "com.squareup:otto:1.3.8"
-    compile "com.squareup.picasso:picasso:2.5.2"
+    compile 'com.github.bumptech.glide:glide:3.7.0'
     compile "com.squareup.retrofit2:retrofit:2.2.0"
     compile 'com.squareup.retrofit2:converter-gson:2.2.0'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'

--- a/src/main/java/org/amahi/anywhere/adapter/FilesFilterBaseAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/FilesFilterBaseAdapter.java
@@ -31,7 +31,7 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.ImageView;
 
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.server.client.ServerClient;
@@ -192,10 +192,9 @@ public abstract class FilesFilterBaseAdapter extends BaseAdapter implements Filt
     }
 
     void setUpImageIcon(ServerFile file, ImageView fileIconView) {
-        Picasso.with(fileIconView.getContext())
+        Glide.with(fileIconView.getContext())
                 .load(getImageUri(file))
                 .centerCrop()
-                .fit()
                 .placeholder(getFileIcon(file))
                 .into(fileIconView);
     }

--- a/src/main/java/org/amahi/anywhere/adapter/ServerAppsAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerAppsAdapter.java
@@ -28,7 +28,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.bus.AppSelectedEvent;
@@ -73,11 +73,11 @@ public class ServerAppsAdapter extends RecyclerView.Adapter<ServerAppsAdapter.Se
 		if(TextUtils.isEmpty(apps.get(position).getLogoUrl()))
 			holder.logo.setImageResource(R.drawable.ic_app_logo);
 		else {
-			Picasso
+			Glide
 					.with(mContext)
 					.load(apps.get(position).getLogoUrl())
-					.fit()
-					.centerInside()
+					.fitCenter()
+					.placeholder(R.drawable.ic_app_logo)
 					.error(R.drawable.ic_app_logo)
 					.into(holder.logo);
 		}

--- a/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
@@ -29,7 +29,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.server.client.ServerClient;
@@ -136,10 +136,10 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter
 		fileTitle.setText(null);
 		fileTitle.setBackgroundResource(android.R.color.transparent);
 
-		Picasso.with(fileView.getContext())
+		Glide.with(fileView.getContext())
 			.load(fileMetadata.getArtworkUrl())
 			.centerCrop()
-			.fit()
+			.fitCenter()
 			.placeholder(getFileIcon(file))
 			.error(getFileIcon(file))
 			.into(fileIcon);

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFileImageFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFileImageFragment.java
@@ -19,15 +19,18 @@
 
 package org.amahi.anywhere.fragment;
 
-import android.support.v4.app.Fragment;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 
-import com.squareup.picasso.Callback;
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
 
 import org.amahi.anywhere.AmahiApplication;
 import org.amahi.anywhere.R;
@@ -42,8 +45,7 @@ import javax.inject.Inject;
 /**
  * Image fragment. Shows a single image.
  */
-public class ServerFileImageFragment extends Fragment implements Callback
-{
+public class ServerFileImageFragment extends Fragment implements RequestListener<Uri, GlideDrawable> {
 	@Inject
 	ServerClient serverClient;
 
@@ -70,12 +72,11 @@ public class ServerFileImageFragment extends Fragment implements Callback
 	}
 
 	private void setUpImageContent() {
-		Picasso
+		Glide
 			.with(getActivity())
 			.load(getImageUri())
-			.fit()
-			.centerInside()
-			.into(getImageView(), this);
+			.listener(this)
+			.into(getImageView());
 	}
 
 	private Uri getImageUri() {
@@ -94,17 +95,24 @@ public class ServerFileImageFragment extends Fragment implements Callback
 		return (TouchImageView) getView().findViewById(R.id.image);
 	}
 
+	private ProgressBar getProgressBar() {
+		return (ProgressBar) getView().findViewById(android.R.id.progress);
+	}
+
 	@Override
-	public void onSuccess() {
+	public boolean onResourceReady(GlideDrawable resource, Uri model, Target<GlideDrawable> target, boolean isFromMemoryCache, boolean isFirstResource) {
 		showImageContent();
+		return false;
 	}
 
 	private void showImageContent() {
 		getImageView().setVisibility(View.VISIBLE);
+		getProgressBar().setVisibility(View.GONE);
 	}
 
 	@Override
-	public void onError() {
+	public boolean onException(Exception e, Uri model, Target<GlideDrawable> target, boolean isFirstResource) {
+		return false;
 	}
 
 	@Override
@@ -115,8 +123,6 @@ public class ServerFileImageFragment extends Fragment implements Callback
 	}
 
 	private void tearDownImageContent() {
-		Picasso
-			.with(getActivity())
-			.cancelRequest(getImageView());
+		Glide.clear(getImageView());
 	}
 }


### PR DESCRIPTION
This pr aims to resolve #189 .
As discussed there, [Picasso](https://github.com/square/picasso/) was unable to load some images so I have replaced it by [Glide](https://github.com/bumptech/glide). As both of these offer similar functionality so there are not much code changes. Also the app behaves exactly the same as it was before, only now it is able to load all the images (afaik).