### PR TITLE
Fixes #202, replaces static method calls with bus event

### DIFF
--- a/src/main/java/org/amahi/anywhere/bus/FileMetadataRetrievedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/FileMetadataRetrievedEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014 Amahi
+ *
+ * This file is part of Amahi.
+ *
+ * Amahi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Amahi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
+package org.amahi.anywhere.bus;
+
+import android.view.View;
+
+import org.amahi.anywhere.server.model.ServerFile;
+import org.amahi.anywhere.server.model.ServerFileMetadata;
+
+public class FileMetadataRetrievedEvent implements BusEvent {
+    private final ServerFile file;
+    private final ServerFileMetadata fileMetadata;
+    private final View fileView;
+
+    public FileMetadataRetrievedEvent(ServerFile file, ServerFileMetadata fileMetadata, View fileView) {
+        this.file = file;
+        this.fileMetadata = fileMetadata;
+        this.fileView = fileView;
+    }
+
+    public ServerFile getFile() {
+        return file;
+    }
+
+    public ServerFileMetadata getFileMetadata() {
+        return fileMetadata;
+    }
+
+    public View getFileView() {
+        return fileView;
+    }
+}

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -639,6 +639,14 @@ public class ServerFilesFragment extends Fragment implements SwipeRefreshLayout.
 	}
 
 	@Override
+	public void onDestroyView() {
+		super.onDestroyView();
+		if (isMetadataAvailable()) {
+			getFilesMetadataAdapter().tearDownCallbacks();
+		}
+	}
+
+	@Override
 	public void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState);
 

--- a/src/main/java/org/amahi/anywhere/task/FileMetadataRetrievingTask.java
+++ b/src/main/java/org/amahi/anywhere/task/FileMetadataRetrievingTask.java
@@ -23,6 +23,9 @@ import android.os.AsyncTask;
 import android.view.View;
 
 import org.amahi.anywhere.adapter.ServerFilesMetadataAdapter;
+import org.amahi.anywhere.bus.BusEvent;
+import org.amahi.anywhere.bus.BusProvider;
+import org.amahi.anywhere.bus.FileMetadataRetrievedEvent;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerFileMetadata;
@@ -32,6 +35,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 
 public class FileMetadataRetrievingTask extends AsyncTask<Void, Void, ServerFileMetadata> {
+
     private final ServerClient serverClient;
 
     private final Reference<View> fileViewReference;
@@ -42,7 +46,7 @@ public class FileMetadataRetrievingTask extends AsyncTask<Void, Void, ServerFile
     private FileMetadataRetrievingTask(ServerClient serverClient, View fileView) {
         this.serverClient = serverClient;
 
-        this.fileViewReference = new WeakReference<View>(fileView);
+        this.fileViewReference = new WeakReference<>(fileView);
 
         this.share = (ServerShare) fileView.getTag(ServerFilesMetadataAdapter.Tags.SHARE);
         this.file = (ServerFile) fileView.getTag(ServerFilesMetadataAdapter.Tags.FILE);
@@ -71,6 +75,8 @@ public class FileMetadataRetrievingTask extends AsyncTask<Void, Void, ServerFile
             return;
         }
 
-        ServerFilesMetadataAdapter.bindView(file, fileMetadata, fileView);
+        BusEvent busEvent = new FileMetadataRetrievedEvent(file, fileMetadata, fileView);
+        BusProvider.getBus().post(busEvent);
+
     }
 }


### PR DESCRIPTION
This pr replaces the static method calls in `ServerFilesMetadataAdapter` and `FileMetadataRetrievingTask` with bus events and resolves #202.