### PR TITLE
File metadata retrieval related bugs resolved (fixes #204)

### DIFF
--- a/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
@@ -124,7 +124,7 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter
 		fileView.setTag(Tags.SHARE, serverShare);
 		fileView.setTag(Tags.FILE, file);
 
-		FileMetadataRetrievingTask.execute(serverClient, fileView);
+		new FileMetadataRetrievingTask(serverClient, fileView).execute();
 	}
 
 	@Subscribe

--- a/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
@@ -85,7 +85,11 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter
 		if (Mimes.match(file.getMime()) != Mimes.Type.VIDEO) {
 			bindFileView(file, fileView);
 		} else {
-			bindFileMetadataView(file, fileView);
+			if(!file.isMetaDataFetched()) {
+				bindFileMetadataView(file, fileView);
+			} else {
+				bindView(file, file.getFileMetadata(), fileView);
+			}
 		}
 		if (Mimes.match(file.getMime()) == Mimes.Type.IMAGE) {
 			setUpImageIcon(file, fileIcon);
@@ -103,7 +107,7 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter
 		fileIcon.setBackgroundResource(R.color.background_secondary);
 	}
 
-	private static void bindFileView(ServerFile file, View fileView) {
+	private void bindFileView(ServerFile file, View fileView) {
 		TextView fileTitle = (TextView) fileView.getTag(Tags.FILE_TITLE);
 		ImageView fileIcon = (ImageView) fileView.getTag(Tags.FILE_ICON);
 
@@ -129,6 +133,7 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter
 
 	@Subscribe
 	public void onFileMetadataRetrieved(FileMetadataRetrievedEvent event) {
+		event.getFile().setMetaDataFetched(true);
 		bindView(event.getFile(), event.getFileMetadata(), event.getFileView());
 	}
 
@@ -136,6 +141,7 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter
 		if (fileMetadata == null) {
 			bindFileView(file, fileView);
 		} else {
+			file.setFileMetadata(fileMetadata);
 			bindFileMetadataView(file, fileMetadata, fileView);
 		}
 	}

--- a/src/main/java/org/amahi/anywhere/server/client/ServerClient.java
+++ b/src/main/java/org/amahi/anywhere/server/client/ServerClient.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import retrofit2.Callback;
 
 
 /**
@@ -225,17 +226,11 @@ public class ServerClient
 			.build();
 	}
 
-	public ServerFileMetadata getFileMetadata(ServerShare share, ServerFile file) {
+	public void getFileMetadata(ServerShare share, ServerFile file, Callback<ServerFileMetadata> callback) {
         if ((server == null) || (share == null) || (file == null)){
-            return null;
+            return;
         }
-
-		try {
-			return serverApi.getFileMetadata(server.getSession(), file.getName(), share.getTag()).execute().body();
-		} catch (IOException e) {
-			e.printStackTrace();
-			return null;
-		}
+		serverApi.getFileMetadata(server.getSession(), file.getName(), share.getTag()).enqueue(callback);
 	}
 
 	public void getApps() {

--- a/src/main/java/org/amahi/anywhere/server/model/ServerFile.java
+++ b/src/main/java/org/amahi/anywhere/server/model/ServerFile.java
@@ -43,14 +43,18 @@ public class ServerFile implements Parcelable
 	@SerializedName("mtime")
 	private Date modificationTime;
 
-       @SerializedName("size")
-       private long size;
+    @SerializedName("size")
+    private long size;
 
-       public long getSize() {
+    private ServerFileMetadata fileMetadata;
+
+	private boolean isMetaDataFetched;
+
+    public long getSize() {
             return size;
        }
 
-       public void setParentFile(ServerFile parentFile) {
+    public void setParentFile(ServerFile parentFile) {
 		this.parentFile = parentFile;
 	}
 
@@ -68,6 +72,22 @@ public class ServerFile implements Parcelable
 
 	public Date getModificationTime() {
 		return modificationTime;
+	}
+
+    public ServerFileMetadata getFileMetadata() {
+        return fileMetadata;
+    }
+
+    public void setFileMetadata(ServerFileMetadata fileMetadata) {
+        this.fileMetadata = fileMetadata;
+    }
+
+	public boolean isMetaDataFetched() {
+		return isMetaDataFetched;
+	}
+
+	public void setMetaDataFetched(boolean metaDataFetched) {
+		isMetaDataFetched = metaDataFetched;
 	}
 
 	public String getPath() {


### PR DESCRIPTION
As discussed in [this comment](https://github.com/amahi/android/issues/204#issuecomment-294319768), I have removed the async task for fetching the file metadata from server and replaced Retrofit call's `execute` method by `enqueue` method. So this should probably resolve the bug in #204.

Also previously as we scrolled up/down in the list, the metadata for each file was fetched again and again. So now I have implemented a way to save the fetched metadata and from next time onwards using the saved one instead of fetching again. This would save a lot of network requests!