### PR TITLE
Resolves response not closed warning

### DIFF
--- a/src/main/java/org/amahi/anywhere/server/ApiConnectionDetector.java
+++ b/src/main/java/org/amahi/anywhere/server/ApiConnectionDetector.java
@@ -71,6 +71,8 @@ public class ApiConnectionDetector
 				.newCall(httpRequest)
 				.execute();
 
+			httpResponse.body().close();
+
 			Timber.d("Using local address.");
 
 			return serverRoute.getLocalAddress();


### PR DESCRIPTION
This pr resolves the response not closed warning given by OkHttp in idle state: 

```A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
java.lang.Throwable: Explicit termination method 'response.body().close()' not called
    at dalvik.system.CloseGuard.open(CloseGuard.java:180)
    at java.lang.reflect.Method.invoke(Native Method)
    at okhttp3.internal.platform.AndroidPlatform$CloseGuard.createAndOpen(AndroidPlatform.java:272)
    at okhttp3.internal.platform.AndroidPlatform.getStackTraceForCloseable(AndroidPlatform.java:138)
    at okhttp3.RealCall.captureCallStackTrace(RealCall.java:72)
    at okhttp3.RealCall.execute(RealCall.java:60)
    at org.amahi.anywhere.server.ApiConnectionDetector.detect(ApiConnectionDetector.java:72)
    at org.amahi.anywhere.task.ServerConnectionDetectingTask.doInBackground(ServerConnectionDetectingTask.java:47)
    at org.amahi.anywhere.task.ServerConnectionDetectingTask.doInBackground(ServerConnectionDetectingTask.java:34)
    at android.os.AsyncTask$2.call(AsyncTask.java:295)
    at java.util.concurrent.FutureTask.run(FutureTask.java:237)
    at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
    at java.lang.Thread.run(Thread.java:818)
```