### PR TITLE
Made CastOptionsProvider class public

### DIFF
--- a/src/main/java/org/amahi/anywhere/util/CastOptionsProvider.java
+++ b/src/main/java/org/amahi/anywhere/util/CastOptionsProvider.java
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * Cast options provider helper class
  */
-class CastOptionsProvider implements OptionsProvider {
+public class CastOptionsProvider implements OptionsProvider {
 
 	@Override
 	public CastOptions getCastOptions(Context appContext) {


### PR DESCRIPTION
The release build of the app seems to be crashing with the error:

`Caused by: java.lang.IllegalAccessException: java.lang.Class<org.amahi.anywhere.util.CastOptionsProvider> is not accessible from java.lang.Class<com.google.android.gms.cast.framework.CastContext>`.

So made the class public as per this [stackoverflow answer](https://stackoverflow.com/a/39259413/6352482).