### PR TITLE
Use FileProvider to get file URI for API 24+

### DIFF
--- a/src/main/res/xml/file_paths.xml
+++ b/src/main/res/xml/file_paths.xml
@@ -3,4 +3,7 @@
     <external-path
         name="user_images"
         path="Android/data/org.amahi.anywhere/files/Pictures"/>
+    <external-path
+        name="user_downloads"
+        path="Android/data/org.amahi.anywhere/files/Download"/>
 </paths>


### PR DESCRIPTION
Resolves crash on android 7 and above on downloading a file.

```Caused by java.lang.RuntimeException: Could not dispatch event: class org.amahi.anywhere.bus.FileDownloadedEvent to handler [EventHandler public void org.amahi.anywhere.activity.ServerFilesActivity.onFileDownloaded(org.amahi.anywhere.bus.FileDownloadedEvent)]: file:///storage/emulated/0/Android/data/org.amahi.anywhere/files/Download/file_name.ext exposed beyond app through Intent.getData()```
