### PR TITLE
Metadata cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,9 @@ android {
 
 
     defaultConfig {
-        def versionMajor = 2
-        def versionMinor = 9
-        def versionPatch = 4
+        def versionMajor = 3
+        def versionMinor = 0
+        def versionPatch = 0
 
         versionName buildVersionName(versionMajor, versionMinor, versionPatch)
         versionCode buildVersionCode(versionMajor, versionMinor, versionPatch)
@@ -145,6 +145,8 @@ dependencies {
     androidTestCompile 'com.android.support:support-annotations:25.4.0'
     provided 'com.squareup.dagger:dagger-compiler:1.2.5'
     compile 'com.github.wseemann:FFmpegMediaMetadataRetriever:1.0.14'
+    debugCompile 'com.readystatesoftware.chuck:library:1.1.0'
+    releaseCompile 'com.readystatesoftware.chuck:library-no-op:1.1.0'
 }
 
 task generateWrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ dependencies {
     compile 'com.github.wseemann:FFmpegMediaMetadataRetriever:1.0.14'
     debugCompile 'com.readystatesoftware.chuck:library:1.1.0'
     releaseCompile 'com.readystatesoftware.chuck:library-no-op:1.1.0'
+    betaReleaseCompile 'com.readystatesoftware.chuck:library-no-op:1.1.0'
 }
 
 task generateWrapper(type: Wrapper) {

--- a/src/main/java/org/amahi/anywhere/AmahiModule.java
+++ b/src/main/java/org/amahi/anywhere/AmahiModule.java
@@ -31,6 +31,7 @@ import org.amahi.anywhere.activity.ServerFileImageActivity;
 import org.amahi.anywhere.activity.ServerFileVideoActivity;
 import org.amahi.anywhere.activity.ServerFileWebActivity;
 import org.amahi.anywhere.activity.ServerFilesActivity;
+import org.amahi.anywhere.cache.CacheModule;
 import org.amahi.anywhere.fragment.NavigationFragment;
 import org.amahi.anywhere.fragment.ServerAppsFragment;
 import org.amahi.anywhere.fragment.ServerFileDownloadingFragment;
@@ -43,6 +44,7 @@ import org.amahi.anywhere.server.ApiModule;
 import org.amahi.anywhere.service.AudioService;
 import org.amahi.anywhere.service.UploadService;
 import org.amahi.anywhere.service.VideoService;
+import org.amahi.anywhere.task.AudioMetadataRetrievingTask;
 import org.amahi.anywhere.tv.activity.TVWebViewActivity;
 import org.amahi.anywhere.tv.activity.TvPlaybackAudioActivity;
 import org.amahi.anywhere.tv.activity.TvPlaybackVideoActivity;
@@ -63,7 +65,8 @@ import dagger.Provides;
  */
 @Module(
     includes = {
-        ApiModule.class
+        ApiModule.class,
+        CacheModule.class
     },
     injects = {
         AuthenticationActivity.class,
@@ -93,7 +96,8 @@ import dagger.Provides;
         TvPlaybackVideoFragment.class,
         TvPlaybackVideoActivity.class,
         TvPlaybackAudioActivity.class,
-        TvPlaybackAudioFragment.class
+        TvPlaybackAudioFragment.class,
+        AudioMetadataRetrievingTask.class
     }
 )
 class AmahiModule {

--- a/src/main/java/org/amahi/anywhere/activity/NavigationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/NavigationActivity.java
@@ -392,6 +392,7 @@ public class NavigationActivity extends AppCompatActivity implements DrawerLayou
     private static final class State {
         public static final String NAVIGATION_TITLE = "navigation_title";
         public static final String NAVIGATION_DRAWER_VISIBLE = "navigation_drawer_visible";
+
         private State() {
         }
     }

--- a/src/main/java/org/amahi/anywhere/adapter/FilesFilterBaseAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/FilesFilterBaseAdapter.java
@@ -173,46 +173,4 @@ public abstract class FilesFilterBaseAdapter extends BaseAdapter implements Filt
             notifyDataSetChanged();
         }
     }
-
-    class AlbumArtFetcher extends AsyncTask<Void, Void, byte[]> {
-        private final ImageView imageView;
-        private final Uri audioUri;
-        private final Context applicationContext;
-
-        AlbumArtFetcher(ImageView imageView, Uri audioUri, Context applicationContext) {
-            this.imageView = imageView;
-            this.audioUri = audioUri;
-            this.applicationContext = applicationContext;
-        }
-
-        @Override
-        protected byte[] doInBackground(Void... params) {
-            try {
-                MediaMetadataRetriever audioMetadataRetriever = new MediaMetadataRetriever();
-                audioMetadataRetriever.setDataSource(audioUri.toString(), new HashMap<String, String>());
-                return extractAlbumArt(audioMetadataRetriever);
-            } catch (Exception e) {
-                e.printStackTrace();
-                return null;
-            }
-        }
-
-        private byte[] extractAlbumArt(MediaMetadataRetriever audioMetadataRetriever) {
-            return audioMetadataRetriever.getEmbeddedPicture();
-        }
-
-        @Override
-        protected void onPostExecute(byte[] bitmap) {
-            if (bitmap != null) {
-                Glide.with(applicationContext)
-                    .load(bitmap)
-                    .asBitmap()
-                    .diskCacheStrategy(DiskCacheStrategy.ALL)
-                    .centerCrop()
-                    .placeholder(R.drawable.ic_file_audio)
-                    .error(R.drawable.ic_file_audio)
-                    .into(imageView);
-            }
-        }
-    }
 }

--- a/src/main/java/org/amahi/anywhere/adapter/FilesFilterBaseAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/FilesFilterBaseAdapter.java
@@ -19,11 +19,8 @@
 
 package org.amahi.anywhere.adapter;
 
-import android.content.Context;
 import android.graphics.Color;
-import android.media.MediaMetadataRetriever;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -36,14 +33,12 @@ import android.widget.ImageView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
-import org.amahi.anywhere.R;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;
 import org.amahi.anywhere.util.Mimes;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**

--- a/src/main/java/org/amahi/anywhere/adapter/NavigationDrawerAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/NavigationDrawerAdapter.java
@@ -21,6 +21,7 @@ public class NavigationDrawerAdapter extends RecyclerView.Adapter<NavigationDraw
 
     private final List<Integer> navigationItems;
     private Context mContext;
+
     public NavigationDrawerAdapter(Context context, List<Integer> navigationItems) {
         this.navigationItems = navigationItems;
         mContext = context;
@@ -65,6 +66,7 @@ public class NavigationDrawerAdapter extends RecyclerView.Adapter<NavigationDraw
     public static final class NavigationItems {
         public static final int SHARES = 0;
         public static final int APPS = 1;
+
         private NavigationItems() {
         }
     }

--- a/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerFilesMetadataAdapter.java
@@ -159,6 +159,7 @@ public class ServerFilesMetadataAdapter extends FilesFilterBaseAdapter {
         public static final int FILE = R.attr.server_share;
         public static final int FILE_TITLE = R.id.text;
         public static final int FILE_ICON = R.id.icon;
+
         private Tags() {
         }
     }

--- a/src/main/java/org/amahi/anywhere/bus/AudioMetadataRetrievedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/AudioMetadataRetrievedEvent.java
@@ -46,13 +46,13 @@ public class AudioMetadataRetrievedEvent implements BusEvent {
         return viewHolder;
     }
 
-    public void setImageView(ImageView imageView) {
-        this.imageView = imageView;
-    }
-
     @Nullable
     public ImageView getImageView() {
         return imageView;
+    }
+
+    public void setImageView(ImageView imageView) {
+        this.imageView = imageView;
     }
 
     public ServerFile getServerFile() {

--- a/src/main/java/org/amahi/anywhere/bus/AudioMetadataRetrievedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/AudioMetadataRetrievedEvent.java
@@ -19,66 +19,47 @@
 
 package org.amahi.anywhere.bus;
 
-import android.graphics.Bitmap;
+import android.support.annotation.Nullable;
+import android.widget.ImageView;
 
+import org.amahi.anywhere.model.AudioMetadata;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.tv.presenter.MainTVPresenter;
 
 public class AudioMetadataRetrievedEvent implements BusEvent {
-    private final String audioTitle;
-    private final String audioArtist;
-    private final String audioAlbum;
-    private final long duration;
-    private final Bitmap audioAlbumArt;
-    private final MainTVPresenter.ViewHolder viewHolder;
+    private final AudioMetadata metadata;
     private final ServerFile serverFile;
 
-    public AudioMetadataRetrievedEvent(String audioTitle, String audioArtist, String audioAlbum,
-                                       String duration, Bitmap audioAlbumArt,
-                                       MainTVPresenter.ViewHolder viewHolder,
-                                       ServerFile serverFile) {
-        this.audioTitle = audioTitle;
-        this.audioArtist = audioArtist;
-        this.audioAlbum = audioAlbum;
-        if (duration != null) {
-            this.duration = Long.valueOf(duration);
-        } else {
-            this.duration = 0;
-        }
-        this.audioAlbumArt = audioAlbumArt;
-        this.viewHolder = viewHolder;
+    private MainTVPresenter.ViewHolder viewHolder;
+    private ImageView imageView;
+
+    public AudioMetadataRetrievedEvent(AudioMetadata metadata,
+                                       ServerFile serverFile,
+                                       MainTVPresenter.ViewHolder viewHolder) {
+        this.metadata = metadata;
         this.serverFile = serverFile;
+        this.viewHolder = viewHolder;
     }
 
-    public AudioMetadataRetrievedEvent(MainTVPresenter.ViewHolder viewHolder, ServerFile serverFile) {
-        this(null, null, null, null, null, viewHolder, serverFile);
-    }
-
-    public String getAudioTitle() {
-        return audioTitle;
-    }
-
-    public String getAudioArtist() {
-        return audioArtist;
-    }
-
-    public String getAudioAlbum() {
-        return audioAlbum;
-    }
-
-    public Bitmap getAudioAlbumArt() {
-        return audioAlbumArt;
-    }
-
+    @Nullable
     public MainTVPresenter.ViewHolder getViewHolder() {
         return viewHolder;
+    }
+
+    public void setImageView(ImageView imageView) {
+        this.imageView = imageView;
+    }
+
+    @Nullable
+    public ImageView getImageView() {
+        return imageView;
     }
 
     public ServerFile getServerFile() {
         return serverFile;
     }
 
-    public long getDuration() {
-        return duration;
+    public AudioMetadata getAudioMetadata() {
+        return this.metadata;
     }
 }

--- a/src/main/java/org/amahi/anywhere/cache/CacheManager.java
+++ b/src/main/java/org/amahi/anywhere/cache/CacheManager.java
@@ -19,12 +19,15 @@
 
 package org.amahi.anywhere.cache;
 
+import android.Manifest;
 import android.content.Context;
 
 import org.amahi.anywhere.model.AudioMetadata;
 
+import pub.devrel.easypermissions.EasyPermissions;
+
 /**
- * Manager class for managing cache for audio files album art images.
+ * Manager class for managing cache for {@link AudioMetadata}.
  */
 
 public class CacheManager {
@@ -33,48 +36,27 @@ public class CacheManager {
 
     public CacheManager(Context context) {
         memoryCache = new MemoryCache();
-        diskCache = new DiskCache(context);
-    }
-
-/*
-    class AudioMetadataWorkerTask extends AsyncTask<Integer, Void, AudioMetadata> {
-        // Decode image in background.
-        @Override
-        protected AudioMetadata doInBackground(Integer... params) {
-            final String imageKey = String.valueOf(params[0]);
-
-            // Check disk cache in background thread
-            AudioMetadata metadata = memoryCache.getAudioMetadata(imageKey);
-
-            if (metadata == null) { // Not found in disk cache
-                // Process as normal
-                //TODO fetch metadata from internet
-            }
-
-            // Add final metadata to caches
-            addAudioMetadataToCache(imageKey, metadata);
-
-            return metadata;
+        if (EasyPermissions.hasPermissions(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            diskCache = new DiskCache(context);
         }
     }
-*/
-
 
     public AudioMetadata getMetadataFromCache(String key) {
         AudioMetadata metadata = memoryCache.get(key);
-        if (metadata == null) {
+        if (metadata == null && diskCache != null) {
             metadata = diskCache.get(key);
         }
         return metadata;
     }
 
-    public void addAudioMetadataToCache(String key, AudioMetadata metadata) {
+    public void addMetadataToCache(String key, AudioMetadata metadata) {
         // Add to memory cache
         memoryCache.add(key, metadata);
 
-        // Also add to disk cache
-        diskCache.add(key, metadata);
+        if (diskCache != null) {
+            // Also add to disk cache
+            diskCache.add(key, metadata);
+        }
     }
-
 
 }

--- a/src/main/java/org/amahi/anywhere/cache/CacheManager.java
+++ b/src/main/java/org/amahi/anywhere/cache/CacheManager.java
@@ -42,9 +42,12 @@ public class CacheManager {
     }
 
     public AudioMetadata getMetadataFromCache(String key) {
-        AudioMetadata metadata = memoryCache.get(key);
-        if (metadata == null && diskCache != null) {
-            metadata = diskCache.get(key);
+        AudioMetadata metadata = null;
+        if (key != null) {
+            metadata = memoryCache.get(key);
+            if (metadata == null && diskCache != null) {
+                metadata = diskCache.get(key);
+            }
         }
         return metadata;
     }

--- a/src/main/java/org/amahi/anywhere/cache/CacheManager.java
+++ b/src/main/java/org/amahi/anywhere/cache/CacheManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2014 Amahi
+ *
+ * This file is part of Amahi.
+ *
+ * Amahi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Amahi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
+package org.amahi.anywhere.cache;
+
+import android.content.Context;
+
+import org.amahi.anywhere.model.AudioMetadata;
+
+/**
+ * Manager class for managing cache for audio files album art images.
+ */
+
+public class CacheManager {
+    private MemoryCache memoryCache;
+    private DiskCache diskCache;
+
+    public CacheManager(Context context) {
+        memoryCache = new MemoryCache();
+        diskCache = new DiskCache(context);
+    }
+
+/*
+    class AudioMetadataWorkerTask extends AsyncTask<Integer, Void, AudioMetadata> {
+        // Decode image in background.
+        @Override
+        protected AudioMetadata doInBackground(Integer... params) {
+            final String imageKey = String.valueOf(params[0]);
+
+            // Check disk cache in background thread
+            AudioMetadata metadata = memoryCache.getAudioMetadata(imageKey);
+
+            if (metadata == null) { // Not found in disk cache
+                // Process as normal
+                //TODO fetch metadata from internet
+            }
+
+            // Add final metadata to caches
+            addAudioMetadataToCache(imageKey, metadata);
+
+            return metadata;
+        }
+    }
+*/
+
+
+    public AudioMetadata getMetadataFromCache(String key) {
+        AudioMetadata metadata = memoryCache.get(key);
+        if (metadata == null) {
+            metadata = diskCache.get(key);
+        }
+        return metadata;
+    }
+
+    public void addAudioMetadataToCache(String key, AudioMetadata metadata) {
+        // Add to memory cache
+        memoryCache.add(key, metadata);
+
+        // Also add to disk cache
+        diskCache.add(key, metadata);
+    }
+
+
+}

--- a/src/main/java/org/amahi/anywhere/cache/CacheModule.java
+++ b/src/main/java/org/amahi/anywhere/cache/CacheModule.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014 Amahi
+ *
+ * This file is part of Amahi.
+ *
+ * Amahi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Amahi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
+package org.amahi.anywhere.cache;
+
+import android.content.Context;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * Cache dependency injection module.
+ * Provides Singleton {@link CacheManager} for possible consumers.
+ */
+@Module(
+    complete = false,
+    library = true
+)
+public class CacheModule {
+    @Provides
+    @Singleton
+    CacheManager provideCacheManager(Context context) {
+        return new CacheManager(context);
+    }
+}

--- a/src/main/java/org/amahi/anywhere/cache/DiskCache.java
+++ b/src/main/java/org/amahi/anywhere/cache/DiskCache.java
@@ -1,0 +1,209 @@
+package org.amahi.anywhere.cache;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.AsyncTask;
+import android.os.Environment;
+import android.util.Log;
+
+import com.bumptech.glide.disklrucache.DiskLruCache;
+
+import org.amahi.anywhere.BuildConfig;
+import org.amahi.anywhere.model.AudioMetadata;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static android.os.Environment.isExternalStorageRemovable;
+
+/**
+ * Disk cache implementation. Internally uses {@link DiskLruCache}.
+ */
+
+public class DiskCache {
+    private DiskLruCache mDiskLruCache;
+    private final Object mDiskCacheLock = new Object();
+    private boolean mDiskCacheStarting = true;
+    private static final int DISK_CACHE_SIZE = 1024 * 1024 * 10; // 10MB
+    private static final String DISK_CACHE_SUBDIR = "album_arts";
+    private static final int APP_VERSION = 1;
+    private static final int VALUE_COUNT = 5;
+
+    private static final int BITMAP_INDEX = 0;
+    private static final int TITLE_INDEX = 1;
+    private static final int ALBUM_INDEX = 2;
+    private static final int ARTIST_INDEX = 3;
+    private static final int DURATION_INDEX = 4;
+
+    DiskCache(Context context) {
+        File cacheDir = getDiskCacheDir(context, DISK_CACHE_SUBDIR);
+        new InitDiskCacheTask().execute(cacheDir);
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    class InitDiskCacheTask extends AsyncTask<File, Void, Void> {
+        @Override
+        protected Void doInBackground(File... params) {
+            synchronized (mDiskCacheLock) {
+                try {
+                    File cacheDir = params[0];
+                    mDiskLruCache = DiskLruCache.open(cacheDir, APP_VERSION, VALUE_COUNT, DISK_CACHE_SIZE);
+                    mDiskCacheStarting = false; // Finished initialization
+                    mDiskCacheLock.notifyAll(); // Wake any waiting threads
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            return null;
+        }
+    }
+
+    // Creates a unique subdirectory of the designated app cache directory. Tries to use external
+    // but if not mounted, falls back on internal storage.
+    private File getDiskCacheDir(Context context, String uniqueName) {
+        // Check if media is mounted or storage is built-in, if so, try and use external cache dir
+        // otherwise use internal cache dir
+        final String cachePath =
+            Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState()) ||
+                !isExternalStorageRemovable() ? context.getExternalCacheDir().getPath() :
+                context.getCacheDir().getPath();
+
+        return new File(cachePath + File.separator + uniqueName);
+    }
+
+    private boolean writeBitmapToFile(Bitmap bitmap, DiskLruCache.Editor editor) throws IOException {
+        OutputStream out = null;
+        try {
+            out = new FileOutputStream(editor.getFile(BITMAP_INDEX));
+            return bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+        } finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+
+    void add(String key, AudioMetadata metadata) {
+        synchronized (mDiskCacheLock) {
+            if (mDiskLruCache != null && !containsKey(key)) {
+                DiskLruCache.Editor editor = null;
+                try {
+                    editor = mDiskLruCache.edit(key);
+                    if (editor == null) {
+                        return;
+                    }
+
+                    if (writeBitmapToFile(metadata.getAudioAlbumArt(), editor)) {
+                        editor.set(TITLE_INDEX, metadata.getAudioTitle());
+                        editor.set(ALBUM_INDEX, metadata.getAudioAlbum());
+                        editor.set(ARTIST_INDEX, metadata.getAudioArtist());
+                        editor.set(DURATION_INDEX, String.valueOf(metadata.getDuration()));
+                        mDiskLruCache.flush();
+                        editor.commit();
+                        if (BuildConfig.DEBUG) {
+                            Log.d("cache_test_DISK_", "metadata put on disk cache " + key);
+                        }
+                    } else {
+                        editor.abort();
+                        if (BuildConfig.DEBUG) {
+                            Log.d("cache_test_DISK_", "ERROR on: metadata put on disk cache " + key);
+                        }
+                    }
+                } catch (IOException e) {
+                    if (BuildConfig.DEBUG) {
+                        Log.d("cache_test_DISK_", "ERROR on: metadata put on disk cache " + key);
+                    }
+                    try {
+                        if (editor != null) {
+                            editor.abort();
+                        }
+                    } catch (IOException ignored) {
+                    }
+                }
+
+            }
+        }
+
+    }
+
+    private Bitmap getBitmap(DiskLruCache.Value value) {
+        Bitmap bitmap = null;
+        final File file = value.getFile(BITMAP_INDEX);
+        if (file != null) {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+            try {
+                bitmap = BitmapFactory.decodeStream(new FileInputStream(file), null, options);
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            }
+        }
+        return bitmap;
+    }
+
+    public AudioMetadata get(String key) {
+        synchronized (mDiskCacheLock) {
+            // Wait while disk cache is started from background thread
+            while (mDiskCacheStarting) {
+                try {
+                    mDiskCacheLock.wait();
+                } catch (InterruptedException ignored) {
+                }
+            }
+
+            if (mDiskLruCache != null) {
+                AudioMetadata metadata = new AudioMetadata();
+                try {
+                    DiskLruCache.Value value = mDiskLruCache.get(key);
+                    if (value == null) {
+                        return null;
+                    }
+                    metadata.setAudioAlbumArt(getBitmap(value));
+                    metadata.setAudioTitle(value.getString(TITLE_INDEX));
+                    metadata.setAudioAlbum(value.getString(ALBUM_INDEX));
+                    metadata.setAudioArtist(value.getString(ARTIST_INDEX));
+                    metadata.setDuration(Long.valueOf(value.getString(DURATION_INDEX)));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+                if (BuildConfig.DEBUG) {
+                    Log.d("cache_test_DISK_", "metadata read from disk " + key);
+                }
+                return metadata;
+            }
+        }
+        return null;
+    }
+
+    private boolean containsKey(String key) {
+        boolean contained = false;
+        try {
+            contained = mDiskLruCache.get(key) != null;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return contained;
+    }
+
+    public void clearCache() {
+        if (BuildConfig.DEBUG) {
+            Log.d("cache_test_DISK_", "disk cache CLEARED");
+        }
+        try {
+            mDiskLruCache.delete();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public File getCacheFolder() {
+        return mDiskLruCache.getDirectory();
+    }
+}

--- a/src/main/java/org/amahi/anywhere/cache/DiskCache.java
+++ b/src/main/java/org/amahi/anywhere/cache/DiskCache.java
@@ -25,19 +25,19 @@ import static android.os.Environment.isExternalStorageRemovable;
  */
 
 public class DiskCache {
-    private DiskLruCache mDiskLruCache;
-    private final Object mDiskCacheLock = new Object();
-    private boolean mDiskCacheStarting = true;
     private static final int DISK_CACHE_SIZE = 1024 * 1024 * 10; // 10MB
     private static final String DISK_CACHE_SUBDIR = "metadata";
     private static final int APP_VERSION = 1;
     private static final int VALUE_COUNT = 5;
-
     private static final int BITMAP_INDEX = 0;
     private static final int TITLE_INDEX = 1;
     private static final int ALBUM_INDEX = 2;
     private static final int ARTIST_INDEX = 3;
     private static final int DURATION_INDEX = 4;
+
+    private final Object mDiskCacheLock = new Object();
+    private DiskLruCache mDiskLruCache;
+    private boolean mDiskCacheStarting = true;
 
     DiskCache(Context context) {
         File cacheDir = getDiskCacheDir(context, DISK_CACHE_SUBDIR);

--- a/src/main/java/org/amahi/anywhere/cache/MemoryCache.java
+++ b/src/main/java/org/amahi/anywhere/cache/MemoryCache.java
@@ -26,8 +26,11 @@ class MemoryCache {
                 // The cache size will be measured in kilobytes rather than
                 // number of items. Used only bitmap to measure the size since
                 // size of other fields won't make much impact.
-                // size of other fields won't make much impact.
-                return metadata.getAudioAlbumArt().getByteCount() / 1024;
+                if (metadata.getAudioAlbumArt() != null) {
+                    return metadata.getAudioAlbumArt().getByteCount() / 1024;
+                } else {
+                    return 0;
+                }
             }
         };
     }

--- a/src/main/java/org/amahi/anywhere/cache/MemoryCache.java
+++ b/src/main/java/org/amahi/anywhere/cache/MemoryCache.java
@@ -1,0 +1,46 @@
+package org.amahi.anywhere.cache;
+
+import android.util.LruCache;
+
+import org.amahi.anywhere.model.AudioMetadata;
+
+/**
+ * In memory cache implementation. Internally uses {@link android.util.LruCache}.
+ */
+
+class MemoryCache {
+    private LruCache<String, AudioMetadata> mMemoryCache;
+
+
+    MemoryCache() {
+        // Get max available VM memory, exceeding this amount will throw an
+        // OutOfMemory exception. (in kilobytes)
+        final int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
+
+        // Use 1/8th of the available memory for this memory cache.
+        final int cacheSize = maxMemory / 8;
+
+        mMemoryCache = new LruCache<String, AudioMetadata>(cacheSize) {
+            @Override
+            protected int sizeOf(String key, AudioMetadata metadata) {
+                // The cache size will be measured in kilobytes rather than
+                // number of items. Used only bitmap to measure the size since
+                // size of other fields won't make much impact.
+                // size of other fields won't make much impact.
+                return metadata.getAudioAlbumArt().getByteCount() / 1024;
+            }
+        };
+    }
+
+    // to add a new audio metadata object to cache
+    void add(String key, AudioMetadata metadata) {
+        if (get(key) == null) {
+            mMemoryCache.put(key, metadata);
+        }
+    }
+
+    // to retrieve a cached audio metadata object
+    AudioMetadata get(String key) {
+        return mMemoryCache.get(key);
+    }
+}

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -396,7 +396,7 @@ public class ServerFilesFragment extends Fragment implements
 
     private void setUpFilesAdapter() {
         if (!isMetadataAvailable()) {
-            setListAdapter(new ServerFilesAdapter(getActivity(), getActivity().getApplicationContext(), serverClient));
+            setListAdapter(new ServerFilesAdapter(getActivity(), serverClient));
         } else {
             setListAdapter(new ServerFilesMetadataAdapter(getActivity(), serverClient));
         }
@@ -764,6 +764,8 @@ public class ServerFilesFragment extends Fragment implements
         super.onDestroyView();
         if (isMetadataAvailable()) {
             getFilesMetadataAdapter().tearDownCallbacks();
+        } else {
+            getFilesAdapter().tearDownCallbacks();
         }
     }
 

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -803,6 +803,7 @@ public class ServerFilesFragment extends Fragment implements
     private static final class State {
         public static final String FILES = "files";
         public static final String FILES_SORT = "files_sort";
+
         private State() {
         }
     }

--- a/src/main/java/org/amahi/anywhere/model/AudioMetadata.java
+++ b/src/main/java/org/amahi/anywhere/model/AudioMetadata.java
@@ -1,0 +1,57 @@
+package org.amahi.anywhere.model;
+
+import android.graphics.Bitmap;
+
+import java.io.Serializable;
+
+/**
+ * Represents metadata for an audio file.
+ */
+
+public class AudioMetadata implements Serializable {
+    private String audioTitle;
+    private String audioArtist;
+    private String audioAlbum;
+    private long duration;
+    private Bitmap audioAlbumArt;
+
+    public String getAudioTitle() {
+        return audioTitle;
+    }
+
+    public void setAudioTitle(String audioTitle) {
+        this.audioTitle = audioTitle;
+    }
+
+    public String getAudioArtist() {
+        return audioArtist;
+    }
+
+    public void setAudioArtist(String audioArtist) {
+        this.audioArtist = audioArtist;
+    }
+
+    public String getAudioAlbum() {
+        return audioAlbum;
+    }
+
+    public void setAudioAlbum(String audioAlbum) {
+        this.audioAlbum = audioAlbum;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public Bitmap getAudioAlbumArt() {
+        return audioAlbumArt;
+    }
+
+    public void setAudioAlbumArt(Bitmap audioAlbumArt) {
+        this.audioAlbumArt = audioAlbumArt;
+    }
+}

--- a/src/main/java/org/amahi/anywhere/model/AudioMetadata.java
+++ b/src/main/java/org/amahi/anywhere/model/AudioMetadata.java
@@ -1,21 +1,40 @@
+/*
+ * Copyright (c) 2014 Amahi
+ *
+ * This file is part of Amahi.
+ *
+ * Amahi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Amahi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
 package org.amahi.anywhere.model;
 
 import android.graphics.Bitmap;
-
-import java.io.Serializable;
+import android.support.annotation.Nullable;
 
 /**
  * Represents metadata for an audio file.
  */
 
-public class AudioMetadata implements Serializable {
+public class AudioMetadata {
     private String audioTitle;
     private String audioArtist;
     private String audioAlbum;
     private long duration;
     private Bitmap audioAlbumArt;
 
-    public String getAudioTitle() {
+    public @Nullable
+    String getAudioTitle() {
         return audioTitle;
     }
 
@@ -23,7 +42,8 @@ public class AudioMetadata implements Serializable {
         this.audioTitle = audioTitle;
     }
 
-    public String getAudioArtist() {
+    public @Nullable
+    String getAudioArtist() {
         return audioArtist;
     }
 
@@ -31,7 +51,8 @@ public class AudioMetadata implements Serializable {
         this.audioArtist = audioArtist;
     }
 
-    public String getAudioAlbum() {
+    public @Nullable
+    String getAudioAlbum() {
         return audioAlbum;
     }
 
@@ -43,11 +64,14 @@ public class AudioMetadata implements Serializable {
         return duration;
     }
 
-    public void setDuration(long duration) {
-        this.duration = duration;
+    public void setDuration(String duration) {
+        if (duration != null) {
+            this.duration = Long.valueOf(duration);
+        }
     }
 
-    public Bitmap getAudioAlbumArt() {
+    public @Nullable
+    Bitmap getAudioAlbumArt() {
         return audioAlbumArt;
     }
 

--- a/src/main/java/org/amahi/anywhere/model/UploadOption.java
+++ b/src/main/java/org/amahi/anywhere/model/UploadOption.java
@@ -33,6 +33,7 @@ public class UploadOption {
     private int type;
     private String name;
     private int icon;
+
     public UploadOption(@Types int type, String name, int icon) {
         this.name = name;
         this.icon = icon;

--- a/src/main/java/org/amahi/anywhere/server/ApiHeaders.java
+++ b/src/main/java/org/amahi/anywhere/server/ApiHeaders.java
@@ -36,6 +36,7 @@ import okhttp3.Response;
 class ApiHeaders implements Interceptor {
     private final String acceptHeader;
     private final String userAgentHeader;
+
     public ApiHeaders(Context context) {
         this.acceptHeader = getAcceptHeader();
         this.userAgentHeader = getUserAgentHeader(context);
@@ -64,6 +65,7 @@ class ApiHeaders implements Interceptor {
     private static final class HeaderFields {
         public static final String ACCEPT = "Accept";
         public static final String USER_AGENT = "User-Agent";
+
         private HeaderFields() {
         }
     }

--- a/src/main/java/org/amahi/anywhere/server/ApiModule.java
+++ b/src/main/java/org/amahi/anywhere/server/ApiModule.java
@@ -23,6 +23,7 @@ import android.content.Context;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.readystatesoftware.chuck.ChuckInterceptor;
 
 import org.amahi.anywhere.util.Time;
 
@@ -46,10 +47,11 @@ import retrofit2.converter.gson.GsonConverterFactory;
 public class ApiModule {
     @Provides
     @Singleton
-    OkHttpClient provideHttpClient(ApiHeaders headers, HttpLoggingInterceptor logging) {
+    OkHttpClient provideHttpClient(ApiHeaders headers, HttpLoggingInterceptor logging, ChuckInterceptor chuck) {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
         clientBuilder.addInterceptor(headers);
         clientBuilder.addInterceptor(logging);
+        clientBuilder.addInterceptor(chuck);
         return clientBuilder.build();
     }
 
@@ -57,6 +59,12 @@ public class ApiModule {
     @Singleton
     ApiHeaders provideHeaders(Context context) {
         return new ApiHeaders(context);
+    }
+
+    @Provides
+    @Singleton
+    ChuckInterceptor provideChuckInterceptor(Context context) {
+        return new ChuckInterceptor(context);
     }
 
     @Provides

--- a/src/main/java/org/amahi/anywhere/server/model/ServerFile.java
+++ b/src/main/java/org/amahi/anywhere/server/model/ServerFile.java
@@ -22,9 +22,12 @@ package org.amahi.anywhere.server.model;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 
 /**
@@ -105,6 +108,24 @@ public class ServerFile implements Parcelable {
 
     public void setFileMetadata(ServerFileMetadata fileMetadata) {
         this.fileMetadata = fileMetadata;
+    }
+
+    @Nullable
+    public String getUniqueKey() {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(getName().getBytes());
+            md.update(getModificationTime().toString().getBytes());
+            byte[] digest = md.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte aDigest : digest) {
+                sb.append(Integer.toHexString((aDigest & 0xFF) | 0x100).substring(1, 3));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     public boolean isMetaDataFetched() {

--- a/src/main/java/org/amahi/anywhere/server/model/ServerShare.java
+++ b/src/main/java/org/amahi/anywhere/server/model/ServerShare.java
@@ -86,6 +86,7 @@ public class ServerShare implements Parcelable {
         public static final String FILES = "files";
         public static final String MOVIES = "movie";
         public static final String TV = "tv";
+
         private Tag() {
         }
     }

--- a/src/main/java/org/amahi/anywhere/task/AudioMetadataRetrievingTask.java
+++ b/src/main/java/org/amahi/anywhere/task/AudioMetadataRetrievingTask.java
@@ -46,12 +46,10 @@ import javax.inject.Inject;
  * The retrieving itself is done via {@link android.media.MediaMetadataRetriever}.
  */
 public class AudioMetadataRetrievingTask extends AsyncTask<Void, Void, BusEvent> {
-    @Inject
-    CacheManager cacheManager;
-
     private final Uri audioUri;
     private final ServerFile serverFile;
-
+    @Inject
+    CacheManager cacheManager;
     private MainTVPresenter.ViewHolder viewHolder;
     private WeakReference<ImageView> imageViewWeakReference;
 
@@ -83,8 +81,8 @@ public class AudioMetadataRetrievingTask extends AsyncTask<Void, Void, BusEvent>
     @Override
     protected BusEvent doInBackground(Void... parameters) {
         AudioMetadata metadata;
-        String key = serverFile.getName();
-        metadata = cacheManager.getMetadataFromCache(key);
+        String uniqueKey = serverFile.getUniqueKey();
+        metadata = cacheManager.getMetadataFromCache(uniqueKey);
         if (metadata == null) {
             metadata = new AudioMetadata();
             MediaMetadataRetriever audioMetadataRetriever = new MediaMetadataRetriever();
@@ -98,7 +96,8 @@ public class AudioMetadataRetrievingTask extends AsyncTask<Void, Void, BusEvent>
                 metadata.setDuration(audioMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
                 metadata.setAudioAlbumArt(extractAlbumArt(audioMetadataRetriever));
 
-                cacheManager.addMetadataToCache(key, metadata);
+                if (uniqueKey != null)
+                    cacheManager.addMetadataToCache(uniqueKey, metadata);
             } catch (RuntimeException ignored) {
             } finally {
                 audioMetadataRetriever.release();

--- a/src/main/java/org/amahi/anywhere/tv/fragment/TvPlaybackAudioFragment.java
+++ b/src/main/java/org/amahi/anywhere/tv/fragment/TvPlaybackAudioFragment.java
@@ -54,6 +54,7 @@ import org.amahi.anywhere.AmahiApplication;
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.bus.AudioMetadataRetrievedEvent;
 import org.amahi.anywhere.bus.BusProvider;
+import org.amahi.anywhere.model.AudioMetadata;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;
@@ -105,7 +106,7 @@ public class TvPlaybackAudioFragment extends PlaybackFragment {
 
         getAllAudioFiles();
 
-        AudioMetadataRetrievingTask.execute(getFileUri(), getAudioFile());
+        AudioMetadataRetrievingTask.newInstance(getActivity(), getFileUri(), getAudioFile()).execute();
 
         mediaPlayer = new MediaPlayer();
 
@@ -380,10 +381,11 @@ public class TvPlaybackAudioFragment extends PlaybackFragment {
             }
         });
         mPlaybackControlsRow.setTotalTime(mediaPlayer.getDuration());
-        if (event.getAudioAlbumArt() != null) {
+        AudioMetadata metadata = event.getAudioMetadata();
+        if (metadata.getAudioAlbumArt() != null) {
             getBackground().setPadding(0, 0, 0, 0);
-            getBackground().setImageBitmap(event.getAudioAlbumArt());
-            mPlaybackControlsRow.setImageBitmap(getActivity(), event.getAudioAlbumArt());
+            getBackground().setImageBitmap(metadata.getAudioAlbumArt());
+            mPlaybackControlsRow.setImageBitmap(getActivity(), metadata.getAudioAlbumArt());
         } else {
             Drawable audioDrawable = ContextCompat.getDrawable(getActivity(), R.drawable.tv_ic_audio);
             getBackground().setPadding(100, 100, 100, 100);

--- a/src/main/java/org/amahi/anywhere/tv/presenter/AudioDetailsDescriptionPresenter.java
+++ b/src/main/java/org/amahi/anywhere/tv/presenter/AudioDetailsDescriptionPresenter.java
@@ -5,6 +5,7 @@ import android.support.v17.leanback.widget.AbstractDetailsDescriptionPresenter;
 import android.text.format.Formatter;
 
 import org.amahi.anywhere.bus.AudioMetadataRetrievedEvent;
+import org.amahi.anywhere.model.AudioMetadata;
 import org.amahi.anywhere.server.model.ServerFile;
 
 import java.text.SimpleDateFormat;
@@ -20,14 +21,15 @@ public class AudioDetailsDescriptionPresenter extends AbstractDetailsDescription
     @Override
     protected void onBindDescription(ViewHolder viewHolder, Object item) {
         AudioMetadataRetrievedEvent event = (AudioMetadataRetrievedEvent) item;
+        AudioMetadata metadata = event.getAudioMetadata();
 
-        if (event.getAudioTitle() != null)
-            viewHolder.getTitle().setText(event.getAudioTitle());
+        if (metadata.getAudioTitle() != null)
+            viewHolder.getTitle().setText(metadata.getAudioTitle());
         else
             viewHolder.getTitle().setText(event.getServerFile().getName());
 
-        if (event.getAudioAlbum() != null && event.getAudioArtist() != null) {
-            viewHolder.getSubtitle().setText(event.getAudioAlbum() + " - " + event.getAudioArtist());
+        if (metadata.getAudioAlbum() != null && metadata.getAudioArtist() != null) {
+            viewHolder.getSubtitle().setText(metadata.getAudioAlbum() + " - " + metadata.getAudioArtist());
         } else
             viewHolder.getSubtitle().setText(getDate(event.getServerFile()));
 

--- a/src/main/java/org/amahi/anywhere/tv/presenter/MainTVPresenter.java
+++ b/src/main/java/org/amahi/anywhere/tv/presenter/MainTVPresenter.java
@@ -39,6 +39,7 @@ import org.amahi.anywhere.bus.AudioMetadataRetrievedEvent;
 import org.amahi.anywhere.bus.BusProvider;
 import org.amahi.anywhere.bus.FileMetadataRetrievedEvent;
 import org.amahi.anywhere.bus.FileOpeningEvent;
+import org.amahi.anywhere.model.AudioMetadata;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;
@@ -165,7 +166,10 @@ public class MainTVPresenter extends Presenter {
         if (isImage(serverFile)) {
             setUpImageIcon(serverFile, viewHolder.mCardView.getMainImageView(), getImageUri(serverFile));
         } else if (isAudio(serverFile)) {
-            AudioMetadataRetrievingTask.execute(getImageUri(serverFile), serverFile, viewHolder);
+            AudioMetadataRetrievingTask
+                .newInstance(mContext, getImageUri(serverFile), serverFile)
+                .setViewHolder(viewHolder)
+                .execute();
         } else {
             setUpDrawable(serverFile, viewHolder);
         }
@@ -197,10 +201,11 @@ public class MainTVPresenter extends Presenter {
 
     @Subscribe
     public void onAudioMetadataRetrieved(AudioMetadataRetrievedEvent event) {
-        if (event.getAudioAlbumArt() != null) {
+        AudioMetadata metadata = event.getAudioMetadata();
+        if (metadata.getAudioAlbumArt() != null) {
             ViewHolder viewHolder = event.getViewHolder();
             if (viewHolder != null) {
-                viewHolder.mCardView.getMainImageView().setImageBitmap(event.getAudioAlbumArt());
+                viewHolder.mCardView.getMainImageView().setImageBitmap(metadata.getAudioAlbumArt());
             }
         } else
             setUpMusicLogo(event.getViewHolder());

--- a/src/main/java/org/amahi/anywhere/util/AudioMetadataFormatter.java
+++ b/src/main/java/org/amahi/anywhere/util/AudioMetadataFormatter.java
@@ -40,6 +40,10 @@ public final class AudioMetadataFormatter {
         this.audioAlbum = audioAlbum;
     }
 
+    public AudioMetadataFormatter() {
+        this(null, null, null);
+    }
+
     public long getDuration() {
         return duration;
     }

--- a/src/main/java/org/amahi/anywhere/view/PercentageView.java
+++ b/src/main/java/org/amahi/anywhere/view/PercentageView.java
@@ -42,6 +42,7 @@ public class PercentageView {
     public static final int BRIGHTNESS = 2;
     private ViewHolder viewHolder;
     private View view;
+
     public PercentageView(FrameLayout parentView) {
         LayoutInflater inflater = (LayoutInflater) parentView.getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         view = inflater.inflate(R.layout.percentage_view, parentView, false);

--- a/src/main/res/layout/view_server_file_item.xml
+++ b/src/main/res/layout/view_server_file_item.xml
@@ -29,7 +29,7 @@
         android:id="@+id/icon"
         android:layout_width="50dp"
         android:layout_height="50dp"
-        android:layout_marginRight="8dp"
+        android:layout_marginEnd="8dp"
         android:scaleType="centerCrop"
         android:src="@drawable/ic_file_audio" />
 


### PR DESCRIPTION
**Following things have been done:**

- Memory and Disk cache for caching audio metadata for faster loading of song metadata like album art, title etc.
- [Chuck Interceptor](https://github.com/jgilfelt/chuck) for easy debugging of all the api calls