### PR TITLE
Upload ProgressDialog replaced by Dialogfragment in ServerFilesActivity.java

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/IntroductionActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/IntroductionActivity.java
@@ -19,7 +19,6 @@
 
 package org.amahi.anywhere.activity;
 
-import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.Nullable;

--- a/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
@@ -139,7 +139,7 @@ public class ServerFilesActivity extends AppCompatActivity implements EasyPermis
 
     private void setUpUploadDialog() {
         uploadDialogFragment = (ProgressDialogFragment) getFragmentManager().findFragmentByTag("progress_dialog");
-        if(uploadDialogFragment == null) {
+        if (uploadDialogFragment == null) {
             uploadDialogFragment = new ProgressDialogFragment();
         }
     }
@@ -443,12 +443,12 @@ public class ServerFilesActivity extends AppCompatActivity implements EasyPermis
 
     private void uploadFile(File uploadFile) {
         serverClient.uploadFile(0, uploadFile, getShare(), file);
-        uploadDialogFragment.show(getFragmentManager(),"progress_dialog");
+        uploadDialogFragment.show(getFragmentManager(), "progress_dialog");
     }
 
     @Subscribe
     public void onFileUploadProgressEvent(ServerFileUploadProgressEvent fileUploadProgressEvent) {
-        if(uploadDialogFragment.isAdded()){
+        if (uploadDialogFragment.isAdded()) {
             uploadDialogFragment.setProgress(fileUploadProgressEvent.getProgress());
         }
     }

--- a/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
@@ -21,7 +21,6 @@ package org.amahi.anywhere.activity;
 
 import android.Manifest;
 import android.app.DialogFragment;
-import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
@@ -53,6 +52,7 @@ import org.amahi.anywhere.bus.ServerFileUploadCompleteEvent;
 import org.amahi.anywhere.bus.ServerFileUploadProgressEvent;
 import org.amahi.anywhere.bus.UploadClickEvent;
 import org.amahi.anywhere.fragment.GooglePlaySearchFragment;
+import org.amahi.anywhere.fragment.ProgressDialogFragment;
 import org.amahi.anywhere.fragment.ServerFileDownloadingFragment;
 import org.amahi.anywhere.fragment.ServerFilesFragment;
 import org.amahi.anywhere.fragment.UploadBottomSheet;
@@ -91,7 +91,7 @@ public class ServerFilesActivity extends AppCompatActivity implements EasyPermis
     ServerClient serverClient;
     private ServerFile file;
     private FileAction fileAction;
-    private ProgressDialog uploadProgressDialog;
+    private ProgressDialogFragment uploadDialogFragment;
     private File cameraImage;
 
     @Override
@@ -138,11 +138,10 @@ public class ServerFilesActivity extends AppCompatActivity implements EasyPermis
     }
 
     private void setUpUploadDialog() {
-        uploadProgressDialog = new ProgressDialog(this);
-        uploadProgressDialog.setTitle(getString(R.string.message_file_upload_title));
-        uploadProgressDialog.setCancelable(false);
-        uploadProgressDialog.setIndeterminate(false);
-        uploadProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+        uploadDialogFragment = (ProgressDialogFragment) getFragmentManager().findFragmentByTag("progress_dialog");
+        if(uploadDialogFragment == null) {
+            uploadDialogFragment = new ProgressDialogFragment();
+        }
     }
 
     @Override
@@ -444,19 +443,20 @@ public class ServerFilesActivity extends AppCompatActivity implements EasyPermis
 
     private void uploadFile(File uploadFile) {
         serverClient.uploadFile(0, uploadFile, getShare(), file);
-        uploadProgressDialog.show();
+        uploadDialogFragment.show(getFragmentManager(),"progress_dialog");
     }
 
     @Subscribe
     public void onFileUploadProgressEvent(ServerFileUploadProgressEvent fileUploadProgressEvent) {
-        if (uploadProgressDialog.isShowing()) {
-            uploadProgressDialog.setProgress(fileUploadProgressEvent.getProgress());
+        if(uploadDialogFragment.isAdded()){
+            uploadDialogFragment.setProgress(fileUploadProgressEvent.getProgress());
         }
     }
 
     @Subscribe
     public void onFileUploadCompleteEvent(ServerFileUploadCompleteEvent event) {
-        uploadProgressDialog.dismiss();
+
+        uploadDialogFragment.dismiss();
         if (event.wasUploadSuccessful()) {
             Fragments.Operator.at(this).replace(buildFilesFragment(getShare(), file), R.id.container_files);
             Snackbar.make(getParentView(), R.string.message_file_upload_complete, Snackbar.LENGTH_LONG).show();

--- a/src/main/java/org/amahi/anywhere/adapter/ServerSharesAdapter.java
+++ b/src/main/java/org/amahi/anywhere/adapter/ServerSharesAdapter.java
@@ -40,6 +40,7 @@ import java.util.List;
  */
 public class ServerSharesAdapter extends RecyclerView.Adapter<ServerSharesAdapter.ServerShareViewHolder> {
     private List<ServerShare> shares;
+
     public ServerSharesAdapter(Context context) {
         this.shares = Collections.emptyList();
     }

--- a/src/main/java/org/amahi/anywhere/fragment/ProgressDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ProgressDialogFragment.java
@@ -25,7 +25,7 @@ public class ProgressDialogFragment extends DialogFragment {
         return dialog;
     }
 
-    public void setProgress(int progress){
+    public void setProgress(int progress) {
         dialog.setProgress(progress);
     }
 }

--- a/src/main/java/org/amahi/anywhere/fragment/ProgressDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ProgressDialogFragment.java
@@ -1,0 +1,31 @@
+package org.amahi.anywhere.fragment;
+
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.app.ProgressDialog;
+import android.os.Bundle;
+
+import org.amahi.anywhere.R;
+
+/**
+ * Dialog Fragment appears in uploading files.
+ */
+
+public class ProgressDialogFragment extends DialogFragment {
+
+    private ProgressDialog dialog;
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        dialog = new ProgressDialog(getActivity());
+        dialog.setTitle(getString(R.string.message_file_upload_title));
+        dialog.setCancelable(false);
+        dialog.setIndeterminate(false);
+        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+        return dialog;
+    }
+
+    public void setProgress(int progress){
+        dialog.setProgress(progress);
+    }
+}

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -143,7 +143,7 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
     public boolean onPreferenceClick(Preference preference) {
         if (preference.getKey().equals(getString(R.string.preference_key_account_sign_out))) {
             tearDownAccount();
-        } else if(preference.getKey().equals(getString(R.string.preference_key_about_intro))){
+        } else if (preference.getKey().equals(getString(R.string.preference_key_about_intro))) {
             setUpApplicationIntro();
         } else if (preference.getKey().equals(getString(R.string.preference_key_about_version))) {
             setUpApplicationVersion();


### PR DESCRIPTION
This replaces the `ProgressDialog` in `ServerFilesActivity` with a `ProgressDialogFragment` (created by extending DialogFragment).

Closes #255 