### PR TITLE
Fixed error of infinite loading when `amahi anywhere` app is not running at hda server and added feature to reconnect to server by click on retry. Issue #307

### DIFF
--- a/src/main/java/org/amahi/anywhere/bus/ServerConnectionFailedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/ServerConnectionFailedEvent.java
@@ -20,4 +20,15 @@
 package org.amahi.anywhere.bus;
 
 public class ServerConnectionFailedEvent implements BusEvent {
+    private String errorMessage;
+
+    public ServerConnectionFailedEvent(){}
+
+    public ServerConnectionFailedEvent(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
 }

--- a/src/main/java/org/amahi/anywhere/bus/ServerReconnectEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/ServerReconnectEvent.java
@@ -1,8 +1,4 @@
 package org.amahi.anywhere.bus;
 
-/**
- * Created by mohit on 12/3/18.
- */
-
 public class ServerReconnectEvent implements BusEvent {
 }

--- a/src/main/java/org/amahi/anywhere/bus/ServerReconnectEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/ServerReconnectEvent.java
@@ -1,0 +1,8 @@
+package org.amahi.anywhere.bus;
+
+/**
+ * Created by mohit on 12/3/18.
+ */
+
+public class ServerReconnectEvent implements BusEvent {
+}

--- a/src/main/java/org/amahi/anywhere/bus/ServerRouteLoadFailedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/ServerRouteLoadFailedEvent.java
@@ -1,0 +1,19 @@
+package org.amahi.anywhere.bus;
+
+/**
+ * Created by mohit on 12/3/18.
+ */
+
+public class ServerRouteLoadFailedEvent implements BusEvent {
+    private String errorMessage;
+
+    public ServerRouteLoadFailedEvent(){}
+
+    public ServerRouteLoadFailedEvent(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/org/amahi/anywhere/bus/ServerRouteLoadFailedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/ServerRouteLoadFailedEvent.java
@@ -1,9 +1,5 @@
 package org.amahi.anywhere.bus;
 
-/**
- * Created by mohit on 12/3/18.
- */
-
 public class ServerRouteLoadFailedEvent implements BusEvent {
     private String errorMessage;
 

--- a/src/main/java/org/amahi/anywhere/bus/ServerSharesLoadFailedEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/ServerSharesLoadFailedEvent.java
@@ -20,4 +20,14 @@
 package org.amahi.anywhere.bus;
 
 public class ServerSharesLoadFailedEvent implements BusEvent {
+    private String error;
+
+    public ServerSharesLoadFailedEvent(){}
+    public ServerSharesLoadFailedEvent(String error){
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
 }

--- a/src/main/java/org/amahi/anywhere/fragment/NavigationFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/NavigationFragment.java
@@ -43,6 +43,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Spinner;
+import android.widget.Toast;
 
 import com.squareup.otto.Subscribe;
 
@@ -56,6 +57,7 @@ import org.amahi.anywhere.bus.AppsSelectedEvent;
 import org.amahi.anywhere.bus.BusProvider;
 import org.amahi.anywhere.bus.ServerConnectedEvent;
 import org.amahi.anywhere.bus.ServerConnectionChangedEvent;
+import org.amahi.anywhere.bus.ServerReconnectEvent;
 import org.amahi.anywhere.bus.ServersLoadFailedEvent;
 import org.amahi.anywhere.bus.ServersLoadedEvent;
 import org.amahi.anywhere.bus.SettingsSelectedEvent;
@@ -412,6 +414,13 @@ public class NavigationFragment extends Fragment implements AccountManagerCallba
         setUpServerConnection();
         setUpServerNavigation();
         if (CheckTV.isATV(getContext())) launchTV();
+    }
+
+    @Subscribe
+    public void onServerReconnectRequest(ServerReconnectEvent event) {
+        Server server = (Server) getServersSpinner().getSelectedItem();
+
+        setUpServerConnection(server);
     }
 
     private void setUpServerConnection() {

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -29,6 +29,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.Toast;
 
 import com.squareup.otto.Subscribe;
 
@@ -37,6 +38,8 @@ import org.amahi.anywhere.R;
 import org.amahi.anywhere.adapter.ServerSharesAdapter;
 import org.amahi.anywhere.bus.BusProvider;
 import org.amahi.anywhere.bus.ServerConnectionChangedEvent;
+import org.amahi.anywhere.bus.ServerConnectionFailedEvent;
+import org.amahi.anywhere.bus.ServerReconnectEvent;
 import org.amahi.anywhere.bus.ServerSharesLoadFailedEvent;
 import org.amahi.anywhere.bus.ServerSharesLoadedEvent;
 import org.amahi.anywhere.server.client.ServerClient;
@@ -150,6 +153,28 @@ public class ServerSharesFragment extends Fragment {
         if (serverClient.isConnected()) {
             serverClient.getShares();
         }
+    }
+
+    @Subscribe
+    public void onServerConnectionFailed(ServerConnectionFailedEvent event) {
+        Toast.makeText(getContext(), getResources()
+            .getString(R.string.message_error_amahi_anywhere_app), Toast.LENGTH_LONG).show();
+        showConnectionError();
+    }
+
+    private void showConnectionError() {
+        ViewDirector.of(getActivity(), R.id.animator).show(R.id.error);
+        mErrorLinearLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                ViewDirector.of(getActivity(), R.id.animator).show(android.R.id.progress);
+                retryServerConnection();
+            }
+        });
+    }
+
+    private void retryServerConnection() {
+        BusProvider.getBus().post(new ServerReconnectEvent());
     }
 
     @Subscribe

--- a/src/main/java/org/amahi/anywhere/server/client/ServerClient.java
+++ b/src/main/java/org/amahi/anywhere/server/client/ServerClient.java
@@ -29,7 +29,9 @@ import org.amahi.anywhere.bus.NetworkChangedEvent;
 import org.amahi.anywhere.bus.ServerConnectedEvent;
 import org.amahi.anywhere.bus.ServerConnectionChangedEvent;
 import org.amahi.anywhere.bus.ServerConnectionDetectedEvent;
+import org.amahi.anywhere.bus.ServerConnectionFailedEvent;
 import org.amahi.anywhere.bus.ServerFileUploadCompleteEvent;
+import org.amahi.anywhere.bus.ServerRouteLoadFailedEvent;
 import org.amahi.anywhere.bus.ServerRouteLoadedEvent;
 import org.amahi.anywhere.server.Api;
 import org.amahi.anywhere.server.ApiAdapter;
@@ -154,7 +156,7 @@ public class ServerClient {
     }
 
     public boolean isConnected(Server server) {
-        return (this.server != null) && (this.server.getSession().equals(server.getSession()));
+        return (this.server != null) && (this.serverRoute != null) && (this.server.getSession().equals(server.getSession()));
     }
 
     public boolean isConnectedLocal() {
@@ -189,6 +191,16 @@ public class ServerClient {
         this.serverRoute = event.getServerRoute();
 
         finishServerConnection();
+    }
+
+    @Subscribe
+    public void onServerRouteLoadFailed(ServerRouteLoadFailedEvent event) {
+        this.serverRoute = null;
+        serverConnectionFailed(event.getErrorMessage());
+    }
+
+    private void serverConnectionFailed(String errorMessage) {
+        BusProvider.getBus().post(new ServerConnectionFailedEvent(errorMessage));
     }
 
     private void finishServerConnection() {

--- a/src/main/java/org/amahi/anywhere/server/response/ServerRouteResponse.java
+++ b/src/main/java/org/amahi/anywhere/server/response/ServerRouteResponse.java
@@ -21,6 +21,7 @@ package org.amahi.anywhere.server.response;
 
 import org.amahi.anywhere.bus.BusProvider;
 import org.amahi.anywhere.bus.ServerConnectionFailedEvent;
+import org.amahi.anywhere.bus.ServerRouteLoadFailedEvent;
 import org.amahi.anywhere.bus.ServerRouteLoadedEvent;
 import org.amahi.anywhere.server.model.ServerRoute;
 
@@ -44,6 +45,6 @@ public class ServerRouteResponse implements Callback<ServerRoute> {
 
     @Override
     public void onFailure(Call<ServerRoute> call, Throwable t) {
-        BusProvider.getBus().post(new ServerConnectionFailedEvent());
+        BusProvider.getBus().post(new ServerRouteLoadFailedEvent(t.getMessage()));
     }
 }

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -28,6 +28,7 @@
     <color name="secondary_text">#757575</color>
     <color name="icons">#FFFFFF</color>
     <color name="divider">#BDBDBD</color>
+    <color name="error_red">#d32f2f</color>
 
     <color name="background_primary">#1a1a1a</color>
     <color name="background_secondary">#333333</color>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="message_error_connection">Connection Error</string>
     <string name="message_tap_to_retry">Tap to retry</string>
     <string name="message_error_video">Error playing the video</string>
-    <string name="message_error_amahi_anywhere_app">Your Amahi server may not be running Amahi Anywhere. Please ensure the Amahi Anywhere app is installed and running.</string>
+    <string name="message_error_amahi_anywhere_app">The Amahi Anywhere app in your server is not reachable. Please ensure that Amahi Anywhere app is installed, running and reachable in your network.</string>
 
 
     <string name="message_notice_check_settings">Check your settings and try again</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="message_error_connection">Connection Error</string>
     <string name="message_tap_to_retry">Tap to retry</string>
     <string name="message_error_video">Error playing the video</string>
+    <string name="message_error_amahi_anywhere_app">Your Amahi server may not be running Amahi Anywhere. Please ensure the Amahi Anywhere app is installed and running.</string>
+
 
     <string name="message_notice_check_settings">Check your settings and try again</string>
     <string name="message_notice_create_some">Create some and try again</string>


### PR DESCRIPTION
Fixed error of infinite loading when `amahi anywhere` app is not running at hda server.
Also now user can initiate reconnect to server by clicking retry button on error screen.

I tried to follow amahi code structure for creating events and flow of events.