### PR TITLE
Uri permissions for open files intent

### DIFF
--- a/src/main/java/org/amahi/anywhere/util/Intents.java
+++ b/src/main/java/org/amahi/anywhere/util/Intents.java
@@ -179,8 +179,17 @@ public final class Intents {
         public Intent buildServerFileOpeningIntent(ServerFile file, Uri fileUri) {
             Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.setDataAndType(fileUri, file.getMime());
+            grantUriPermission(intent, fileUri);
 
             return Intent.createChooser(intent, null);
+        }
+
+        private void grantUriPermission(Intent intent, Uri fileUri) {
+            List<ResolveInfo> resolvedIntentActivities = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+            for (ResolveInfo resolvedIntentInfo : resolvedIntentActivities) {
+                String packageName = resolvedIntentInfo.activityInfo.packageName;
+                context.grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            }
         }
 
         public Intent buildServerFileSharingIntent(ServerFile file, Uri fileUri) {


### PR DESCRIPTION
Now files like pdf, doc, txt, xls, etc can be opened directly with intent.
![20180312_171528](https://user-images.githubusercontent.com/23583851/37282269-cf0e84b0-2619-11e8-8205-cf81aff24e1d.gif)

Closes #290 