### PR TITLE
Fix for the issue #394

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ android:
     - extra-android-m2repository
     - extra-google-m2repository
     - sys-img-armeabi-v7a-android-19
-  licenses:
-    - .+
+
+    licenses:
+    - '.+'
 
 before_script:
   - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'io.fabric.tools:gradle:1.22.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'io.fabric.tools:gradle:1.25.4'
     }
 }
 
@@ -16,7 +16,7 @@ apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '27.0.1'
+    buildToolsVersion '28.0.3'
 
     signingConfigs {
         release {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Nov 26 20:09:44 IST 2017
+#Sun Dec 30 12:35:24 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
(Building Error)Android Gradle plugin supports only Crashlytics Gradle plugin version 1.25.4 and higher.
 changed the build.gradle file classpath 'io.fabric.tools:gradle:1.22.1' to classpath 'io.fabric.tools:gradle:1.25.4'.