### PR TITLE
Completed TODO in strings.xml

### DIFF
--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -74,10 +74,9 @@
 
 
     <string name="message_notice_check_settings">Vérifiez vos paramètres et réessayez</string>
-
-    <!-- TODO: Translate those, missing some context here -->
-    <string name="message_notice_create_some">Create some and try again</string>
-    <string name="message_notice_visit_some">Visit some and try again</string>
+    
+    <string name="message_notice_create_some">Créez-en et essayez à nouveau</string>
+    <string name="message_notice_visit_some">Visitez-en et essayez encore</string>
 
     <string name="message_progress_file_downloading">Téléchargement du fichier …</string>
     <string name="message_progress_file_preparing">Préparation du fichier …</string>


### PR DESCRIPTION
Added translation for message_notice_create_some and message_notice_visit_some

I saw a TODO in strings.xml and I completed it accordingly and removed the TODO comment in strings.xml.
Translations added:
`<string name="message_notice_create_some">Créez-en et essayez à nouveau</string>`
`<string name="message_notice_visit_some">Visitez-en et essayez encore</string>`