### PR TITLE
Removed extra string resource from values-fr/strings.xml

### DIFF
--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -19,9 +19,6 @@
 
 <resources>
 
-    <string name="application_name" translatable="false">Amahi</string>
-
-
     <string name="title_apps">Apps</string>
     <string name="title_settings">Paramètres</string>
     <string name="title_shares">Partages</string>
@@ -74,7 +71,7 @@
 
 
     <string name="message_notice_check_settings">Vérifiez vos paramètres et réessayez</string>
-    
+
     <string name="message_notice_create_some">Créez-en et essayez à nouveau</string>
     <string name="message_notice_visit_some">Visitez-en et essayez encore</string>
 


### PR DESCRIPTION
application_name was marked as untranslatable in strings.xml but was still defined in values-fr/strings.xml so it was removed.