### PR TITLE
fix: Sign Out in Settings doesn't ask for confirmation

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -23,6 +23,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.AccountManagerCallback;
 import android.accounts.AccountManagerFuture;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -131,7 +132,7 @@ public class SettingsFragment extends PreferenceFragment implements
         Preference autoUpload = getPreference(R.string.preference_screen_key_upload);
 
         accountSignOut.setOnPreferenceClickListener(preference -> {
-            tearDownAccount();
+            setConfirmationDialog();
             return true;
         });
         applicationIntro.setOnPreferenceClickListener(preference -> {
@@ -169,6 +170,14 @@ public class SettingsFragment extends PreferenceFragment implements
 
     private void openUploadSettingsFragment() {
         BusProvider.getBus().post(new UploadSettingsOpeningEvent());
+    }
+
+    private void setConfirmationDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(getString(R.string.sign_out_title))
+            .setMessage(getString(R.string.sign_out_message))
+            .setPositiveButton(getString(R.string.sign_out_title), (dialog, which) -> tearDownAccount())
+            .setNegativeButton(getString(R.string.cancel), (dialog, which) -> dialog.dismiss()).show();
     }
 
     private void tearDownAccount() {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -140,6 +140,9 @@
     <string name="selected_server_session">SERVER_SESSION</string>
     <string name="exit_title">Exit</string>
     <string name="exit_message">Are you sure you want to quit?</string>
+    <string name="sign_out_title">Sign Out</string>
+    <string name="sign_out_message">Are you sure you want to sign out?</string>
+    <string name="cancel">Cancel</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
 


### PR DESCRIPTION
Fixes #435 

**Screenshots**

![sign-out-dialog](https://user-images.githubusercontent.com/26673203/54181262-fae2f480-44c3-11e9-9acf-dea0a52a6301.jpg)

An Alert dialog is added to ask for sign out confirmation. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
