### PR TITLE
Feature: Sort files by descending order of size

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -119,6 +119,7 @@ public class ServerFilesFragment extends Fragment implements
 
     public static final int SORT_MODIFICATION_TIME = 0;
     public static final int SORT_NAME = 1;
+    public static final int SORT_SIZE = 2;
 
     @Inject
     ServerClient serverClient;
@@ -643,6 +644,9 @@ public class ServerFilesFragment extends Fragment implements
             case SORT_MODIFICATION_TIME:
                 return new FileModificationTimeComparator();
 
+            case SORT_SIZE:
+                return new FileSizeComparator();
+
             default:
                 return null;
         }
@@ -786,6 +790,10 @@ public class ServerFilesFragment extends Fragment implements
                 menuItem.setIcon(R.drawable.ic_menu_sort_modification_time);
                 break;
 
+            case SORT_SIZE:
+                menuItem.setIcon(R.drawable.ic_menu_sort_size);
+                break;
+
             default:
                 break;
         }
@@ -811,6 +819,10 @@ public class ServerFilesFragment extends Fragment implements
                 break;
 
             case SORT_MODIFICATION_TIME:
+                filesSort = SORT_SIZE;
+                break;
+
+            case SORT_SIZE:
                 filesSort = SORT_NAME;
                 break;
 
@@ -958,7 +970,7 @@ public class ServerFilesFragment extends Fragment implements
             getView().findViewById(R.id.none_text).setVisibility(empty ? View.VISIBLE : View.GONE);
     }
 
-    @IntDef({SORT_MODIFICATION_TIME, SORT_NAME})
+    @IntDef({SORT_MODIFICATION_TIME, SORT_NAME, SORT_SIZE})
     public @interface Types {
     }
 
@@ -981,6 +993,13 @@ public class ServerFilesFragment extends Fragment implements
         @Override
         public int compare(ServerFile firstFile, ServerFile secondFile) {
             return -firstFile.getModificationTime().compareTo(secondFile.getModificationTime());
+        }
+    }
+
+    private static final class FileSizeComparator implements Comparator<ServerFile> {
+        @Override
+        public int compare(ServerFile firstFile, ServerFile secondFile) {
+            return -Long.compare(firstFile.getSize(), secondFile.getSize());
         }
     }
 }

--- a/src/main/res/drawable/ic_menu_sort_size.xml
+++ b/src/main/res/drawable/ic_menu_sort_size.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="16"
+    android:viewportHeight="16"
+    android:width="36dp"
+    android:height="36dp">
+    <path
+        android:pathData="M1 1L1 2L8 2L8 1L1 1zM11 2L11 2.5L11 11.042969L8.7285156 8.7714844L8.0214844 9.4785156L11.5 12.957031L14.978516 9.4785156L14.271484 8.7714844L12 11.042969L12 2.5L12 2L11 2zM1 3L1 4L7 4L7 3L1 3zM1 5L1 6L6 6L6 5L1 5zM1 7L1 8L5 8L5 7L1 7zM1 9L1 10L4 10L4 9L1 9zM1 11L1 12L3 12L3 11L1 11zM1 13L1 14L2 14L2 13L1 13z"
+        android:fillColor="#ffffff" />
+</vector>


### PR DESCRIPTION
Fixes #441 

**Screenshots**

![sort-size](https://user-images.githubusercontent.com/26673203/54538203-db633480-49b9-11e9-96d7-530a8cd589cc.gif)


**Summary of the changes made**

Added sort_size icon and the flow of icons goes like this : sort_name - > sort_modification_time - > sort_size - > sort_name 
A comparator class is added to ServerFilesFragment to compare sizes of files in the list and sort them in descending order.
