### PR TITLE
Add Notification Channels configuration for Android O

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     implementation "com.android.support:customtabs:${SUPPORT_LIBRARY_VERSION}"
     implementation "com.android.support:leanback-v17:${SUPPORT_LIBRARY_VERSION}"
     implementation "com.android.support:mediarouter-v7:${SUPPORT_LIBRARY_VERSION}"
+    implementation "com.android.support:support-media-compat:${SUPPORT_LIBRARY_VERSION}"
     implementation "com.android.support:cardview-v7:${SUPPORT_LIBRARY_VERSION}"
     implementation 'com.google.android.gms:play-services-cast-framework:11.6.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.6.6@aar') {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
 

--- a/src/main/java/org/amahi/anywhere/util/MediaNotificationManager.java
+++ b/src/main/java/org/amahi/anywhere/util/MediaNotificationManager.java
@@ -20,6 +20,8 @@
 package org.amahi.anywhere.util;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -27,15 +29,19 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Build;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.media.app.NotificationCompat.MediaStyle;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
+import android.support.v4.media.session.MediaButtonReceiver;
 import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
-import android.support.v7.app.NotificationCompat;
 import android.util.Log;
 
 import org.amahi.anywhere.R;
@@ -55,7 +61,7 @@ public class MediaNotificationManager extends BroadcastReceiver {
     private static final int NOTIFICATION_ID = 412;
     private static final int REQUEST_CODE = 100;
     private static final String TAG = "notification_manager";
-
+    private static final String CHANNEL_ID = "media_playback_channel";
     private final AudioService mService;
     private final NotificationManagerCompat mNotificationManager;
     private final PendingIntent mPauseIntent;
@@ -228,13 +234,36 @@ public class MediaNotificationManager extends BroadcastReceiver {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
+    private void createChannel() {
+        Log.i(TAG, "createChannel: ");
+        NotificationManager
+            mNotificationManager =
+            (NotificationManager) mService
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+        // The id of the channel.
+        String id = CHANNEL_ID;
+        // The user-visible name of the channel.
+        CharSequence name = "Media playback";
+        // The user-visible description of the channel.
+        String description = "Media playback controls";
+        int importance = NotificationManager.IMPORTANCE_LOW;
+        NotificationChannel mChannel = new NotificationChannel(id, name, importance);
+        // Configure the notification channel.
+        mChannel.setDescription(description);
+        mChannel.setShowBadge(false);
+        mChannel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
+        mNotificationManager.createNotificationChannel(mChannel);
+    }
+
+
     private Notification createNotification() {
-        Log.d(TAG, "updateNotificationMetadata. mMetadata=" + mMetadata);
         if (mMetadata == null || mPlaybackState == null) {
             return null;
         }
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mService);
+        NotificationCompat.Builder notificationBuilder =
+            new NotificationCompat.Builder(mService, CHANNEL_ID);
         notificationBuilder.addAction(android.R.drawable.ic_media_previous,
             mService.getString(R.string.label_previous), mPreviousIntent);
 
@@ -251,10 +280,18 @@ public class MediaNotificationManager extends BroadcastReceiver {
             audioAlbumArt = BitmapFactory.decodeResource(mService.getResources(), R.drawable.default_audiotrack);
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createChannel();
+        }
+
         notificationBuilder
-            .setStyle(new NotificationCompat.MediaStyle()
-                .setShowActionsInCompactView(1)  // show only play/pause in compact view
-                .setMediaSession(mSessionToken))
+            .setStyle(
+                new MediaStyle()
+                    .setMediaSession(mSessionToken)
+                    .setShowCancelButton(true)
+                    .setCancelButtonIntent(
+                        MediaButtonReceiver.buildMediaButtonPendingIntent(
+                            mService, PlaybackStateCompat.ACTION_STOP)))
             .setSmallIcon(getAudioPlayerNotificationIcon())
             .setLargeIcon(getAudioPlayerNotificationArtwork(audioAlbumArt))
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -262,7 +299,7 @@ public class MediaNotificationManager extends BroadcastReceiver {
             .setContentTitle(description.getTitle())
             .setContentText(description.getSubtitle())
             .setOngoing(mPlaybackState.getState() == PlaybackStateCompat.STATE_PLAYING);
-//        setNotificationPlaybackState(notificationBuilder);
+        //setNotificationPlaybackState(notificationBuilder);
         return notificationBuilder.build();
     }
 


### PR DESCRIPTION
In response to my own issue #443 I tried to add the support myself.
Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel or it will not appear. By categorizing notifications into channels, users can disable specific notification channels for your app (instead of disabling all your notifications), and users can control the visual and auditory options for each channel—all from the Android system settings. Users can also long-press a notification to change behaviors for the associated channel.

You can read more about Notification channel here-
https://developer.android.com/preview/features/notification-channels.html

`<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />`
I've added this to `AndroidManifest.xml `as it is required by android P.
