### PR TITLE
Add register button in login activity

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -23,7 +23,9 @@ import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
 import android.app.Activity;
+import android.content.Intent;
 import android.graphics.PorterDuff;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.ContextCompat;
@@ -99,6 +101,10 @@ public class AuthenticationActivity extends AccountAuthenticatorActivity impleme
         return findViewById(R.id.button_authentication);
     }
 
+    private ActionProcessButton getRegisterButton() {
+        return findViewById(R.id.button_register);
+    }
+
     private void setUpAuthenticationMessages() {
         TextView authenticationFailureMessage = findViewById(R.id.text_message_authentication);
         TextView authenticationConnectionFailureMessage = findViewById(R.id.text_message_authentication_connection);
@@ -110,6 +116,7 @@ public class AuthenticationActivity extends AccountAuthenticatorActivity impleme
     private void setUpAuthenticationListeners() {
         setUpAuthenticationTextListener();
         setUpAuthenticationActionListener();
+        setUpRegisterActionListener();
     }
 
     private void setUpAuthenticationTextListener() {
@@ -144,6 +151,15 @@ public class AuthenticationActivity extends AccountAuthenticatorActivity impleme
 
     private void setUpAuthenticationActionListener() {
         getAuthenticationButton().setOnClickListener(this::onClick);
+    }
+
+    private void setUpRegisterActionListener() {
+        getRegisterButton().setOnClickListener(this::onRegisterClick);
+    }
+
+    private void onRegisterClick(View view) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.amahi.org/signup"));
+        startActivity(browserIntent);
     }
 
     public void onClick(View view) {

--- a/src/main/res/layout/layout_authentication.xml
+++ b/src/main/res/layout/layout_authentication.xml
@@ -19,9 +19,9 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_gravity="center"
     android:orientation="vertical"
     android:paddingLeft="32dp"
@@ -30,10 +30,10 @@
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:ignore="contentDescription"
         android:paddingLeft="32dp"
         android:paddingRight="32dp"
-        android:src="@drawable/ic_banner" />
+        android:src="@drawable/ic_banner"
+        tools:ignore="contentDescription" />
 
     <Space
         android:layout_width="match_parent"
@@ -80,11 +80,20 @@
         android:layout_height="16dp" />
 
     <com.dd.processbutton.iml.ActionProcessButton
-        android:contentDescription="@string/sign_in"
         android:id="@+id/button_authentication"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:contentDescription="@string/sign_in"
         android:text="@string/button_sign_in"
+        android:textColor="@android:color/white" />
+
+    <com.dd.processbutton.iml.ActionProcessButton
+        android:id="@+id/button_register"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/register"
+        android:text="@string/button_register"
         android:textColor="@android:color/white" />
 
     <Space

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="button_yes">Yes</string>
     <string name="button_no">No</string>
     <string name="button_retry">Retry</string>
+    <string name="button_register">Create a new account</string>
 
     <string name="hint_password">Password</string>
     <string name="hint_username">Username</string>
@@ -181,5 +182,6 @@
     <string name="pause_the_audio" translatable="false">"Pause the audio"</string>
     <string name="upload" translatable="false">"Upload"</string>
     <string name="sign_in" translatable="false">"Sign in"</string>
+    <string name="register" translatable="false">"Create a new account"</string>
 
 </resources>


### PR DESCRIPTION
For the new user, there is no direct create account option in the login page. It would be better if there is an option like "Create an account" on the login page as shown in gif.

![Register](https://user-images.githubusercontent.com/39567362/54820237-6f881100-4cc4-11e9-8684-beddc4c16fad.gif)