### PR TITLE
Fix: Query in the Search bar is not preserved on screen rotation

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -132,6 +132,7 @@ public class ServerFilesFragment extends Fragment implements
     private ProgressDialog deleteProgressDialog;
     private int deleteFilePosition;
     private int lastSelectedFilePosition = -1;
+    private CharSequence searchQuery = null;
 
     @Types
     private int filesSort = SORT_MODIFICATION_TIME;
@@ -149,6 +150,11 @@ public class ServerFilesFragment extends Fragment implements
             rootView = layoutInflater.inflate(R.layout.fragment_server_files_metadata, container, false);
         }
         mErrorLinearLayout = rootView.findViewById(R.id.error);
+
+        if (savedInstanceState != null) {
+            searchQuery = savedInstanceState.getCharSequence(State.SEARCH_QUERY);
+        }
+
         return rootView;
     }
 
@@ -748,6 +754,14 @@ public class ServerFilesFragment extends Fragment implements
         mediaRouteMenuItem = CastButtonFactory.setUpMediaRouteButton(
             getActivity().getApplicationContext(),
             menu, R.id.media_route_menu_item);
+
+        searchMenuItem = menu.findItem(R.id.menu_search);
+        searchView = (SearchView) searchMenuItem.getActionView();
+
+        if (searchQuery != null) {
+            searchMenuItem.expandActionView();
+            searchView.setQuery(searchQuery, true);
+        }
     }
 
     @Override
@@ -755,8 +769,7 @@ public class ServerFilesFragment extends Fragment implements
         super.onPrepareOptionsMenu(menu);
 
         setUpFilesContentSortIcon(menu.findItem(R.id.menu_sort));
-        searchMenuItem = menu.findItem(R.id.menu_search);
-        searchView = (SearchView) searchMenuItem.getActionView();
+
 
         setUpSearchView();
         setSearchCursor();
@@ -914,6 +927,9 @@ public class ServerFilesFragment extends Fragment implements
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+        if (searchView.isShown()) {
+            outState.putCharSequence(State.SEARCH_QUERY, searchView.getQuery());
+        }
 
         tearDownFilesState(outState);
         outState.putInt(State.SELECTED_ITEM, lastSelectedFilePosition);
@@ -977,6 +993,7 @@ public class ServerFilesFragment extends Fragment implements
     private static final class State {
         public static final String FILES = "files";
         public static final String SELECTED_ITEM = "selected_item";
+        public static final String SEARCH_QUERY = "search_query";
 
         private State() {
         }


### PR DESCRIPTION
Fixes #462 

The ServerFilesActivity is recreated on screen rotation, which is being done automatically by the system. But here we don't need to recreate the activity, so on adding configChanges property to the activity, we restrict the activity to not recreate due to the phone orientation change.

**Screenshots**
![orientation-came](https://user-images.githubusercontent.com/26673203/55830700-21319980-5b2f-11e9-9ddc-1a1b9e673a99.gif)

**Summary**
Added configChanges property to the ServerFilesActivity so that it won't recreate on screen rotation.