### PR TITLE
Fix: Alert dialogs doesn't persist on screen rotation

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/RecentFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/RecentFilesActivity.java
@@ -14,7 +14,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 import android.support.design.widget.Snackbar;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
@@ -45,6 +44,7 @@ import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.entities.RecentFile;
 import org.amahi.anywhere.db.repositories.OfflineFileRepository;
 import org.amahi.anywhere.db.repositories.RecentFileRepository;
+import org.amahi.anywhere.fragment.AlertDialogFragment;
 import org.amahi.anywhere.fragment.PrepareDialogFragment;
 import org.amahi.anywhere.fragment.ServerFileDownloadingFragment;
 import org.amahi.anywhere.model.FileOption;
@@ -71,7 +71,8 @@ public class RecentFilesActivity extends AppCompatActivity implements
     ServerFileClickListener,
     SwipeRefreshLayout.OnRefreshListener,
     EasyPermissions.PermissionCallbacks,
-    CastStateListener {
+    CastStateListener,
+    AlertDialogFragment.DeleteFileDialogCallback {
 
     @Inject
     ServerClient serverClient;
@@ -442,16 +443,23 @@ public class RecentFilesActivity extends AppCompatActivity implements
     }
 
     private void deleteFile() {
+        AlertDialogFragment deleteFileDialog = new AlertDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.DELETE_FILE_DIALOG);
+        deleteFileDialog.setArguments(bundle);
+        deleteFileDialog.show(getSupportFragmentManager(), "delete_dialog");
+    }
 
-        new AlertDialog.Builder(this)
-            .setTitle(R.string.message_delete_file_title)
-            .setMessage(R.string.message_delete_file_body)
-            .setPositiveButton(R.string.button_yes, (dialog, which) -> {
-                showDeleteDialog();
-                serverClient.deleteFile(getSelectedRecentFile().getShareName(), prepareServerFile(getSelectedRecentFile()));
-            })
-            .setNegativeButton(R.string.button_no, null)
-            .show();
+    @Override
+    public void dialogPositiveButtonOnClick() {
+        showDeleteDialog();
+        serverClient.deleteFile(getSelectedRecentFile().getShareName(), prepareServerFile(getSelectedRecentFile()));
+
+    }
+
+    @Override
+    public void dialogNegativeButtonOnClick() {
+
     }
 
     private void showDeleteDialog() {

--- a/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
@@ -37,7 +37,6 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.FileProvider;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
@@ -62,6 +61,7 @@ import org.amahi.anywhere.bus.UploadClickEvent;
 import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.repositories.OfflineFileRepository;
 import org.amahi.anywhere.fragment.AudioControllerFragment;
+import org.amahi.anywhere.fragment.AlertDialogFragment;
 import org.amahi.anywhere.fragment.GooglePlaySearchFragment;
 import org.amahi.anywhere.fragment.PrepareDialogFragment;
 import org.amahi.anywhere.fragment.ProgressDialogFragment;
@@ -101,7 +101,8 @@ import timber.log.Timber;
 public class ServerFilesActivity extends AppCompatActivity implements
     EasyPermissions.PermissionCallbacks,
     ServiceConnection,
-    CastStateListener {
+    CastStateListener,
+    AlertDialogFragment.DuplicateFileDialogCallback {
 
     private static final int FILE_UPLOAD_PERMISSION = 102;
     private static final int CAMERA_PERMISSION = 103;
@@ -444,12 +445,22 @@ public class ServerFilesActivity extends AppCompatActivity implements
     }
 
     private void showDuplicateFileUploadDialog(final File file) {
-        new AlertDialog.Builder(this)
-            .setTitle(R.string.message_duplicate_file_upload)
-            .setMessage(getString(R.string.message_duplicate_file_upload_body, file.getName()))
-            .setPositiveButton(R.string.button_yes, (dialog, which) -> uploadFile(file))
-            .setNegativeButton(R.string.button_no, null)
-            .show();
+        AlertDialogFragment duplicateFileDialog = new AlertDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.DUPLICATE_FILE_DIALOG);
+        bundle.putSerializable("file", file);
+        duplicateFileDialog.setArguments(bundle);
+        duplicateFileDialog.show(getSupportFragmentManager(), "duplicate_file_dialog");
+    }
+
+    @Override
+    public void dialogPositiveButtonOnClick(File file) {
+        uploadFile(file);
+    }
+
+    @Override
+    public void dialogNegativeButtonOnClick() {
+
     }
 
     private void uploadFile(File uploadFile) {

--- a/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
@@ -1,0 +1,153 @@
+package org.amahi.anywhere.fragment;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+
+import android.app.AlertDialog;
+import android.support.v4.app.DialogFragment;
+import android.util.Log;
+
+import org.amahi.anywhere.R;
+import org.amahi.anywhere.util.Fragments;
+
+import java.io.File;
+
+public class AlertDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
+    File file;
+    private int dialogType = -1;
+    AlertDialog.Builder builder;
+    public static final int DELETE_FILE_DIALOG = 0;
+    public static final int DUPLICATE_FILE_DIALOG = 1;
+
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        builder = new android.app.AlertDialog.Builder(getActivity());
+
+        if (getArguments() != null) {
+            dialogType = getArguments().getInt(Fragments.Arguments.DIALOG_TYPE);
+        }
+
+        switch (dialogType) {
+            case DELETE_FILE_DIALOG:
+                buildDeleteDialog();
+                break;
+
+            case DUPLICATE_FILE_DIALOG:
+                buildDuplicateDialog();
+                break;
+        }
+
+        return builder.create();
+    }
+
+    private void buildDeleteDialog() {
+        builder.setTitle(getString(R.string.message_delete_file_title))
+            .setMessage(getString(R.string.message_delete_file_body))
+            .setPositiveButton(getString(R.string.button_yes), this)
+            .setNegativeButton(getString(R.string.button_no), this);
+    }
+
+    private void buildDuplicateDialog() {
+        file = (File) getArguments().getSerializable("file");
+        builder.setTitle(getString(R.string.message_duplicate_file_upload))
+            .setMessage(getString(R.string.message_duplicate_file_upload_body, file.getName()))
+            .setPositiveButton(getString(R.string.button_yes), this)
+            .setNegativeButton(getString(R.string.button_no), this);
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+
+        if (dialogType == DUPLICATE_FILE_DIALOG) {
+            DuplicateFileDialogCallback callback = getDuplicateDialogCallback();
+
+            if (callback != null) {
+                if (which == DialogInterface.BUTTON_POSITIVE) {
+                    dialog.dismiss();
+                    callback.dialogPositiveButtonOnClick(file);
+                } else if (which == DialogInterface.BUTTON_NEGATIVE) {
+                    dialog.dismiss();
+                    callback.dialogNegativeButtonOnClick();
+                }
+            }
+
+        } else if (dialogType == DELETE_FILE_DIALOG) {
+            DeleteFileDialogCallback callback = getDeleteDialogCallback();
+
+            if (callback != null) {
+                if (which == DialogInterface.BUTTON_POSITIVE) {
+                    dialog.dismiss();
+                    callback.dialogPositiveButtonOnClick();
+                } else if (which == DialogInterface.BUTTON_NEGATIVE) {
+                    dialog.dismiss();
+                    callback.dialogNegativeButtonOnClick();
+                }
+            }
+        }
+
+
+    }
+
+    private DuplicateFileDialogCallback getDuplicateDialogCallback() {
+        DuplicateFileDialogCallback callback;
+        if (getTargetFragment() != null) {
+            try {
+                callback = (DuplicateFileDialogCallback) getTargetFragment();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by target fragment!", e);
+                throw e;
+            }
+        } else {
+            try {
+                callback = (DuplicateFileDialogCallback) getActivity();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by the activity!", e);
+                throw e;
+            }
+        }
+        return callback;
+    }
+
+    private DeleteFileDialogCallback getDeleteDialogCallback() {
+        DeleteFileDialogCallback callback;
+        if (getTargetFragment() != null) {
+            try {
+                callback = (DeleteFileDialogCallback) getTargetFragment();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by target fragment!", e);
+                throw e;
+            }
+        } else {
+            try {
+                callback = (DeleteFileDialogCallback) getActivity();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by the activity!", e);
+                throw e;
+            }
+        }
+        return callback;
+    }
+
+
+    public interface DuplicateFileDialogCallback {
+
+        void dialogPositiveButtonOnClick(File file);
+
+
+        void dialogNegativeButtonOnClick();
+    }
+
+    public interface DeleteFileDialogCallback {
+
+        void dialogPositiveButtonOnClick();
+
+
+        void dialogNegativeButtonOnClick();
+    }
+
+}

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -36,7 +36,6 @@ import android.support.annotation.RequiresApi;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
@@ -114,7 +113,8 @@ public class ServerFilesFragment extends Fragment implements
     SearchView.OnQueryTextListener,
     FilesFilterAdapter.onFilterListChange,
     EasyPermissions.PermissionCallbacks,
-    CastStateListener {
+    CastStateListener,
+    AlertDialogFragment.DeleteFileDialogCallback {
     public final static int EXTERNAL_STORAGE_PERMISSION = 101;
 
     public static final int SORT_MODIFICATION_TIME = 0;
@@ -335,18 +335,31 @@ public class ServerFilesFragment extends Fragment implements
     private void deleteFile() {
         if (!isOfflineFragment()) {
             deleteFilePosition = getListAdapter().getSelectedPosition();
-            new AlertDialog.Builder(getContext())
-                .setTitle(R.string.message_delete_file_title)
-                .setMessage(R.string.message_delete_file_body)
-                .setPositiveButton(R.string.button_yes, (dialog, which) -> {
-                    deleteProgressDialog.show();
-                    serverClient.deleteFile(getShare(), getCheckedFile());
-                })
-                .setNegativeButton(R.string.button_no, null)
-                .show();
+            showDeleteConfirmationDialog();
         } else {
             BusProvider.getBus().post(new OfflineFileDeleteEvent(getCheckedFile()));
         }
+    }
+
+    private void showDeleteConfirmationDialog() {
+        AlertDialogFragment deleteFileDialog = new AlertDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.DELETE_FILE_DIALOG);
+        deleteFileDialog.setArguments(bundle);
+        deleteFileDialog.setTargetFragment(this, 2);
+        deleteFileDialog.show(getFragmentManager(), "delete_dialog");
+    }
+
+    @Override
+    public void dialogPositiveButtonOnClick() {
+        deleteProgressDialog.show();
+        serverClient.deleteFile(getShare(), getCheckedFile());
+
+    }
+
+    @Override
+    public void dialogNegativeButtonOnClick() {
+
     }
 
     private void changeOfflineState(boolean enable) {

--- a/src/main/res/layout-land/intro_first_layout.xml
+++ b/src/main/res/layout-land/intro_first_layout.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="20dp"
+        app:srcCompat="@drawable/ic_banner"
+        tools:ignore="contentDescription"/>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/imageView"
+        android:layout_centerHorizontal="true"
+        android:layout_marginEnd="40dp"
+        android:layout_marginStart="40dp"
+        android:layout_marginTop="20dp">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/text_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="16dp"
+                android:text="@string/intro_phone_1"
+                android:textColor="@android:color/white"
+                android:textSize="20sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/text_title"
+                android:padding="16dp"
+                android:gravity="center"
+                android:text="@string/intro_desc_phone_1"
+                android:textSize="15sp" />
+        </RelativeLayout>
+    </android.support.v7.widget.CardView>
+
+
+</RelativeLayout>


### PR DESCRIPTION
Fixes #468 

**Screenshots**

For duplicate file upload dialog:

![alert-dialog1](https://user-images.githubusercontent.com/26673203/56079346-c63ec180-5e10-11e9-9793-4324b16f0204.gif)

For delete file dialog in both ServerFilesFragment, RecentFilesActivity:

![alert-dialog2](https://user-images.githubusercontent.com/26673203/56079347-c63ec180-5e10-11e9-8565-dd8a9fc295a8.gif)


**Summary**
The alert dialogs are changed to dialog fragments
Implementing alert dialogs as dialog fragments is an easier way to prevent them from disapearing when the screen orientation is changed.

