### PR TITLE
Fix: Alert dialogs doesn't persist on screen rotation

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/RecentFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/RecentFilesActivity.java
@@ -14,7 +14,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 import android.support.design.widget.Snackbar;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
@@ -45,6 +44,7 @@ import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.entities.RecentFile;
 import org.amahi.anywhere.db.repositories.OfflineFileRepository;
 import org.amahi.anywhere.db.repositories.RecentFileRepository;
+import org.amahi.anywhere.fragment.AlertDialogFragment;
 import org.amahi.anywhere.fragment.PrepareDialogFragment;
 import org.amahi.anywhere.fragment.ServerFileDownloadingFragment;
 import org.amahi.anywhere.model.FileOption;
@@ -71,7 +71,8 @@ public class RecentFilesActivity extends AppCompatActivity implements
     ServerFileClickListener,
     SwipeRefreshLayout.OnRefreshListener,
     EasyPermissions.PermissionCallbacks,
-    CastStateListener {
+    CastStateListener,
+    AlertDialogFragment.DeleteFileDialogCallback {
 
     @Inject
     ServerClient serverClient;
@@ -92,6 +93,11 @@ public class RecentFilesActivity extends AppCompatActivity implements
         setUpCast();
         setUpHomeNavigation();
         setUpFilesContentRefreshing();
+
+        //retrieving preserved selected item (if any) on screen rotation
+        if (savedInstanceState != null && savedInstanceState.containsKey(State.SELECTED_ITEM)) {
+            this.selectedPosition = savedInstanceState.getInt(State.SELECTED_ITEM);
+        }
     }
 
     private void setUpInjections() {
@@ -442,16 +448,23 @@ public class RecentFilesActivity extends AppCompatActivity implements
     }
 
     private void deleteFile() {
+        AlertDialogFragment deleteFileDialog = new AlertDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.DELETE_FILE_DIALOG);
+        deleteFileDialog.setArguments(bundle);
+        deleteFileDialog.show(getSupportFragmentManager(), "delete_dialog");
+    }
 
-        new AlertDialog.Builder(this)
-            .setTitle(R.string.message_delete_file_title)
-            .setMessage(R.string.message_delete_file_body)
-            .setPositiveButton(R.string.button_yes, (dialog, which) -> {
-                showDeleteDialog();
-                serverClient.deleteFile(getSelectedRecentFile().getShareName(), prepareServerFile(getSelectedRecentFile()));
-            })
-            .setNegativeButton(R.string.button_no, null)
-            .show();
+    @Override
+    public void dialogPositiveButtonOnClick() {
+        showDeleteDialog();
+        serverClient.deleteFile(getSelectedRecentFile().getShareName(), prepareServerFile(getSelectedRecentFile()));
+
+    }
+
+    @Override
+    public void dialogNegativeButtonOnClick() {
+
     }
 
     private void showDeleteDialog() {
@@ -526,6 +539,13 @@ public class RecentFilesActivity extends AppCompatActivity implements
         startService(downloadService);
     }
 
+    private static final class State {
+        public static final String SELECTED_ITEM = "selected_item";
+
+        private State() {
+        }
+    }
+
     @Override
     protected void onResume() {
         super.onResume();
@@ -555,6 +575,13 @@ public class RecentFilesActivity extends AppCompatActivity implements
             menu, R.id.media_route_menu_item);
 
         return true;
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        //to preserve selected item on screen rotation
+        outState.putInt(State.SELECTED_ITEM, selectedPosition);
     }
 
     @Override

--- a/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
@@ -37,7 +37,6 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.FileProvider;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
@@ -62,6 +61,7 @@ import org.amahi.anywhere.bus.UploadClickEvent;
 import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.repositories.OfflineFileRepository;
 import org.amahi.anywhere.fragment.AudioControllerFragment;
+import org.amahi.anywhere.fragment.AlertDialogFragment;
 import org.amahi.anywhere.fragment.GooglePlaySearchFragment;
 import org.amahi.anywhere.fragment.PrepareDialogFragment;
 import org.amahi.anywhere.fragment.ProgressDialogFragment;
@@ -101,7 +101,8 @@ import timber.log.Timber;
 public class ServerFilesActivity extends AppCompatActivity implements
     EasyPermissions.PermissionCallbacks,
     ServiceConnection,
-    CastStateListener {
+    CastStateListener,
+    AlertDialogFragment.DuplicateFileDialogCallback {
 
     private static final int FILE_UPLOAD_PERMISSION = 102;
     private static final int CAMERA_PERMISSION = 103;
@@ -444,12 +445,23 @@ public class ServerFilesActivity extends AppCompatActivity implements
     }
 
     private void showDuplicateFileUploadDialog(final File file) {
-        new AlertDialog.Builder(this)
-            .setTitle(R.string.message_duplicate_file_upload)
-            .setMessage(getString(R.string.message_duplicate_file_upload_body, file.getName()))
-            .setPositiveButton(R.string.button_yes, (dialog, which) -> uploadFile(file))
-            .setNegativeButton(R.string.button_no, null)
-            .show();
+
+        AlertDialogFragment duplicateFileDialog = new AlertDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.DUPLICATE_FILE_DIALOG);
+        bundle.putSerializable("file", file);
+        duplicateFileDialog.setArguments(bundle);
+        duplicateFileDialog.show(getSupportFragmentManager(), "duplicate_file_dialog");
+    }
+
+    @Override
+    public void dialogPositiveButtonOnClick(File file) {
+        uploadFile(file);
+    }
+
+    @Override
+    public void dialogNegativeButtonOnClick() {
+
     }
 
     private void uploadFile(File uploadFile) {

--- a/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
@@ -1,0 +1,153 @@
+package org.amahi.anywhere.fragment;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+
+import android.app.AlertDialog;
+import android.support.v4.app.DialogFragment;
+import android.util.Log;
+
+import org.amahi.anywhere.R;
+import org.amahi.anywhere.util.Fragments;
+
+import java.io.File;
+
+public class AlertDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
+    File file;
+    private int dialogType = -1;
+    AlertDialog.Builder builder;
+    public static final int DELETE_FILE_DIALOG = 0;
+    public static final int DUPLICATE_FILE_DIALOG = 1;
+
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        builder = new android.app.AlertDialog.Builder(getActivity());
+
+        if (getArguments() != null) {
+            dialogType = getArguments().getInt(Fragments.Arguments.DIALOG_TYPE);
+        }
+
+        switch (dialogType) {
+            case DELETE_FILE_DIALOG:
+                buildDeleteDialog();
+                break;
+
+            case DUPLICATE_FILE_DIALOG:
+                buildDuplicateDialog();
+                break;
+        }
+
+        return builder.create();
+    }
+
+    private void buildDeleteDialog() {
+        builder.setTitle(getString(R.string.message_delete_file_title))
+            .setMessage(getString(R.string.message_delete_file_body))
+            .setPositiveButton(getString(R.string.button_yes), this)
+            .setNegativeButton(getString(R.string.button_no), this);
+    }
+
+    private void buildDuplicateDialog() {
+        file = (File) getArguments().getSerializable("file");
+        builder.setTitle(getString(R.string.message_duplicate_file_upload))
+            .setMessage(getString(R.string.message_duplicate_file_upload_body, file.getName()))
+            .setPositiveButton(getString(R.string.button_yes), this)
+            .setNegativeButton(getString(R.string.button_no), this);
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+
+        if (dialogType == DUPLICATE_FILE_DIALOG) {
+            DuplicateFileDialogCallback callback = getDuplicateDialogCallback();
+
+            if (callback != null) {
+                if (which == DialogInterface.BUTTON_POSITIVE) {
+                    dialog.dismiss();
+                    callback.dialogPositiveButtonOnClick(file);
+                } else if (which == DialogInterface.BUTTON_NEGATIVE) {
+                    dialog.dismiss();
+                    callback.dialogNegativeButtonOnClick();
+                }
+            }
+
+        } else if (dialogType == DELETE_FILE_DIALOG) {
+            DeleteFileDialogCallback callback = getDeleteDialogCallback();
+
+            if (callback != null) {
+                if (which == DialogInterface.BUTTON_POSITIVE) {
+                    dialog.dismiss();
+                    callback.dialogPositiveButtonOnClick();
+                } else if (which == DialogInterface.BUTTON_NEGATIVE) {
+                    dialog.dismiss();
+                    callback.dialogNegativeButtonOnClick();
+                }
+            }
+        }
+
+
+    }
+
+    private DuplicateFileDialogCallback getDuplicateDialogCallback() {
+        DuplicateFileDialogCallback callback;
+        if (getTargetFragment() != null) {
+            try {
+                callback = (DuplicateFileDialogCallback) getTargetFragment();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by target fragment!", e);
+                throw e;
+            }
+        } else {
+            try {
+                callback = (DuplicateFileDialogCallback) getActivity();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by the activity!", e);
+                throw e;
+            }
+        }
+        return callback;
+    }
+
+    private DeleteFileDialogCallback getDeleteDialogCallback() {
+        DeleteFileDialogCallback callback;
+        if (getTargetFragment() != null) {
+            try {
+                callback = (DeleteFileDialogCallback) getTargetFragment();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by target fragment!", e);
+                throw e;
+            }
+        } else {
+            try {
+                callback = (DeleteFileDialogCallback) getActivity();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by the activity!", e);
+                throw e;
+            }
+        }
+        return callback;
+    }
+
+
+    public interface DuplicateFileDialogCallback {
+
+        void dialogPositiveButtonOnClick(File file);
+
+
+        void dialogNegativeButtonOnClick();
+    }
+
+    public interface DeleteFileDialogCallback {
+
+        void dialogPositiveButtonOnClick();
+
+
+        void dialogNegativeButtonOnClick();
+    }
+
+}


### PR DESCRIPTION
Fixes #468

**Screenshots**

For duplicate file upload dialog:

![duplicate-dialog](https://user-images.githubusercontent.com/26673203/56456740-3a87e080-638e-11e9-8185-223756e7a609.gif)


For delete file dialog (both ServerFilesFragment, RecentFilesActivity):

![delete-dialog](https://user-images.githubusercontent.com/26673203/56456746-3fe52b00-638e-11e9-9414-89e2cfee2613.gif)


**Summary**
Implementing alert dialogs as dialog fragments is an easier way to prevent them from disappearing when the screen orientation is changed. So the alert dialogs are changed to AlertDialogs.

A single AlertDialogFragment is created to handle all the alert dialogs. Right now delete file, duplicate file dialogs are implemented.

For delete file dialog:
The index of selected item from the list of files is preserved using onSaveInstanceState, so as to preserve the selected item on screen rotation (in both ServerFilesFragment and RecentFilesActivity).


