### PR TITLE
Fix: Dialogs in Settings screen disappear on screen rotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:${SUPPORT_LIBRARY_VERSION}"
     implementation "com.google.android.material:material:${SUPPORT_LIBRARY_VERSION}"
     implementation "androidx.preference:preference:${SUPPORT_LIBRARY_VERSION}"
+    implementation "androidx.legacy:legacy-preference-v14:${SUPPORT_LIBRARY_VERSION}"
     implementation "androidx.browser:browser:${SUPPORT_LIBRARY_VERSION}"
     implementation "androidx.leanback:leanback:${SUPPORT_LIBRARY_VERSION}"
     implementation "androidx.mediarouter:mediarouter:${SUPPORT_LIBRARY_VERSION}"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -122,7 +122,8 @@
         <activity android:name=".activity.ServerFileWebActivity" />
         <activity
             android:name=".activity.SettingsActivity"
-            android:label="@string/title_settings" />
+            android:label="@string/title_settings"
+            android:theme="@style/Theme.Amahi.Settings"/>
         <activity
             android:name=".activity.IntroductionActivity"
             android:label="@string/intro_desc_phone_1"

--- a/src/main/java/org/amahi/anywhere/activity/SettingsActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/SettingsActivity.java
@@ -19,11 +19,14 @@
 
 package org.amahi.anywhere.activity;
 
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+
 import android.view.MenuItem;
 
 import com.squareup.otto.Subscribe;
@@ -55,7 +58,9 @@ public class SettingsActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_settings);
 
-        setUpSettingsFragment();
+        if (savedInstanceState == null) {
+            setUpSettingsFragment();
+        }
     }
 
     private void setUpHomeNavigation() {
@@ -64,7 +69,7 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     private void setUpSettingsFragment() {
-        FragmentManager fragmentManager = getFragmentManager();
+        FragmentManager fragmentManager = getSupportFragmentManager();
         fragmentManager.beginTransaction().setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
             .replace(R.id.settings_container, new SettingsFragment()).commit();
     }
@@ -83,7 +88,7 @@ public class SettingsActivity extends AppCompatActivity {
 
     @Subscribe
     public void onUploadSettingsOpenEvent(UploadSettingsOpeningEvent event) {
-        getFragmentManager().beginTransaction()
+        getSupportFragmentManager().beginTransaction()
             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
             .replace(R.id.settings_container, new UploadSettingsFragment())
             .addToBackStack(null)

--- a/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
@@ -3,10 +3,13 @@ package org.amahi.anywhere.fragment;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 
 import android.app.AlertDialog;
+
 import androidx.fragment.app.DialogFragment;
+
 import android.util.Log;
 
 import org.amahi.anywhere.R;
@@ -20,6 +23,7 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
     AlertDialog.Builder builder;
     public static final int DELETE_FILE_DIALOG = 0;
     public static final int DUPLICATE_FILE_DIALOG = 1;
+    public static final int SIGN_OUT_DIALOG = 2;
 
 
     @NonNull
@@ -40,6 +44,9 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
             case DUPLICATE_FILE_DIALOG:
                 buildDuplicateDialog();
                 break;
+
+            case SIGN_OUT_DIALOG:
+                buildSignOutDialog();
         }
 
         return builder.create();
@@ -60,6 +67,13 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
             .setNegativeButton(getString(R.string.button_no), this);
     }
 
+    private void buildSignOutDialog() {
+        builder.setTitle(getString(R.string.sign_out_title))
+            .setMessage(getString(R.string.sign_out_message))
+            .setPositiveButton(getString(R.string.sign_out_title), this)
+            .setNegativeButton(getString(R.string.cancel), this);
+    }
+
     @Override
     public void onClick(DialogInterface dialog, int which) {
 
@@ -78,6 +92,18 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
 
         } else if (dialogType == DELETE_FILE_DIALOG) {
             DeleteFileDialogCallback callback = getDeleteDialogCallback();
+
+            if (callback != null) {
+                if (which == DialogInterface.BUTTON_POSITIVE) {
+                    dialog.dismiss();
+                    callback.dialogPositiveButtonOnClick();
+                } else if (which == DialogInterface.BUTTON_NEGATIVE) {
+                    dialog.dismiss();
+                    callback.dialogNegativeButtonOnClick();
+                }
+            }
+        } else if (dialogType == SIGN_OUT_DIALOG) {
+            SignOutDialogCallback callback = getSignOutDialogCallback();
 
             if (callback != null) {
                 if (which == DialogInterface.BUTTON_POSITIVE) {
@@ -133,6 +159,27 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
         return callback;
     }
 
+    private SignOutDialogCallback getSignOutDialogCallback() {
+
+        SignOutDialogCallback callback;
+        if (getTargetFragment() != null) {
+            try {
+                callback = (SignOutDialogCallback) getTargetFragment();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by target fragment!", e);
+                throw e;
+            }
+        } else {
+            try {
+                callback = (SignOutDialogCallback) getActivity();
+            } catch (ClassCastException e) {
+                Log.e(this.getClass().getSimpleName(), "Callback of this class must be implemented by the activity!", e);
+                throw e;
+            }
+        }
+        return callback;
+    }
+
 
     public interface DuplicateFileDialogCallback {
 
@@ -143,6 +190,14 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
     }
 
     public interface DeleteFileDialogCallback {
+
+        void dialogPositiveButtonOnClick();
+
+
+        void dialogNegativeButtonOnClick();
+    }
+
+    public interface SignOutDialogCallback {
 
         void dialogPositiveButtonOnClick();
 

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -23,17 +23,20 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.AccountManagerCallback;
 import android.accounts.AccountManagerFuture;
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.ListPreference;
-import android.preference.Preference;
-import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.Nullable;
+
 import com.google.android.material.snackbar.Snackbar;
+
 import androidx.appcompat.app.AppCompatDelegate;
+
 import android.widget.Toast;
 
 import org.amahi.anywhere.AmahiApplication;
@@ -45,6 +48,7 @@ import org.amahi.anywhere.bus.UploadSettingsOpeningEvent;
 import org.amahi.anywhere.server.ApiConnection;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.util.Android;
+import org.amahi.anywhere.util.Fragments;
 import org.amahi.anywhere.util.Intents;
 import org.amahi.anywhere.util.Preferences;
 
@@ -56,9 +60,10 @@ import javax.inject.Inject;
 /**
  * Settings fragment. Shows application's settings.
  */
-public class SettingsFragment extends PreferenceFragment implements
+public class SettingsFragment extends PreferenceFragmentCompat implements
     SharedPreferences.OnSharedPreferenceChangeListener,
-    AccountManagerCallback<Boolean> {
+    AccountManagerCallback<Boolean>,
+    AlertDialogFragment.SignOutDialogCallback {
     @Inject
     ServerClient serverClient;
     public static final int RESULT_THEME_UPDATED = 3;
@@ -67,6 +72,10 @@ public class SettingsFragment extends PreferenceFragment implements
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setUpInjections();
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle bundle, String s) {
         setUpSettings();
     }
 
@@ -135,7 +144,7 @@ public class SettingsFragment extends PreferenceFragment implements
         Preference lightTheme = getPreference(R.string.pref_key_light_theme);
 
         accountSignOut.setOnPreferenceClickListener(preference -> {
-            setConfirmationDialog();
+            setUpSignOutDialogFragment();
             return true;
         });
         applicationIntro.setOnPreferenceClickListener(preference -> {
@@ -194,12 +203,23 @@ public class SettingsFragment extends PreferenceFragment implements
         startActivity(getActivity().getIntent());
     }
 
-    private void setConfirmationDialog() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setTitle(getString(R.string.sign_out_title))
-            .setMessage(getString(R.string.sign_out_message))
-            .setPositiveButton(getString(R.string.sign_out_title), (dialog, which) -> tearDownAccount())
-            .setNegativeButton(getString(R.string.cancel), (dialog, which) -> dialog.dismiss()).show();
+    private void setUpSignOutDialogFragment() {
+        AlertDialogFragment signOutDialogFragment = new AlertDialogFragment();
+        signOutDialogFragment.setTargetFragment(this, 1);
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.SIGN_OUT_DIALOG);
+        signOutDialogFragment.setArguments(bundle);
+        signOutDialogFragment.show(getFragmentManager(), "sign_out_dialog");
+    }
+
+    @Override
+    public void dialogPositiveButtonOnClick() {
+        tearDownAccount();
+    }
+
+    @Override
+    public void dialogNegativeButtonOnClick() {
+
     }
 
     private void tearDownAccount() {

--- a/src/main/java/org/amahi/anywhere/fragment/UploadSettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/UploadSettingsFragment.java
@@ -29,16 +29,23 @@ import android.accounts.OperationCanceledException;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.EditTextPreference;
-import android.preference.ListPreference;
-import android.preference.Preference;
-import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
-import android.preference.SwitchPreference;
+
+import com.google.android.material.textfield.TextInputEditText;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceManager;
+import androidx.preference.SwitchPreference;
+import androidx.fragment.app.DialogFragment;
+import androidx.preference.EditTextPreferenceDialogFragmentCompat;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+
 import com.google.android.material.snackbar.Snackbar;
+
+import android.view.View;
 
 import com.squareup.otto.Subscribe;
 
@@ -54,6 +61,7 @@ import org.amahi.anywhere.server.client.AmahiClient;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.Server;
 import org.amahi.anywhere.server.model.ServerShare;
+import org.amahi.anywhere.util.CustomEditTextPreference;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -68,12 +76,14 @@ import pub.devrel.easypermissions.EasyPermissions;
 /**
  * Upload Settings fragment. Shows upload settings.
  */
-public class UploadSettingsFragment extends PreferenceFragment implements
+public class UploadSettingsFragment extends PreferenceFragmentCompat implements
     Preference.OnPreferenceChangeListener,
     AccountManagerCallback<Bundle>,
     EasyPermissions.PermissionCallbacks {
 
     private static final int READ_PERMISSIONS = 110;
+    private static final String DIALOG_FRAGMENT_TAG =
+        "android.support.v7.preference.PreferenceFragment.DIALOG";
     @Inject
     AmahiClient amahiClient;
 
@@ -90,7 +100,10 @@ public class UploadSettingsFragment extends PreferenceFragment implements
         setUpInjections();
 
         setUpTitle();
+    }
 
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setUpSettings();
     }
 
@@ -263,13 +276,6 @@ public class UploadSettingsFragment extends PreferenceFragment implements
             }
         } else if (key.equals(getString(R.string.preference_key_upload_share))) {
             getSharePreference().setSummary(String.valueOf(newValue));
-        } else if (key.equals(getString(R.string.preference_key_upload_location))) {
-            String location = String.valueOf(newValue);
-            if (location.isEmpty()) {
-                getLocationPreference().setSummary(getString(R.string.preference_summary_location));
-            } else {
-                setUploadLocationSummary(String.valueOf(newValue));
-            }
         }
         return true;
     }
@@ -392,9 +398,87 @@ public class UploadSettingsFragment extends PreferenceFragment implements
         return (ListPreference) getPreference(R.string.preference_key_upload_share);
     }
 
-    private EditTextPreference getLocationPreference() {
-        return (EditTextPreference) getPreference(R.string.preference_key_upload_location);
+    private CustomEditTextPreference getLocationPreference() {
+        return (CustomEditTextPreference) getPreference(R.string.preference_key_upload_location);
     }
+
+    @Override
+    public void onDisplayPreferenceDialog(Preference preference) {
+        if (getFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_TAG) != null) {
+            return;
+        }
+
+        DialogFragment f = null;
+        if (preference instanceof CustomEditTextPreference) {
+            f = EditTextPreferenceDialog.newInstance(preference.getKey());
+        } else {
+            super.onDisplayPreferenceDialog(preference);
+        }
+        if (f != null) {
+            f.setTargetFragment(this, 0);
+            f.show(getFragmentManager(), DIALOG_FRAGMENT_TAG);
+        }
+    }
+
+    public static class EditTextPreferenceDialog extends EditTextPreferenceDialogFragmentCompat {
+        TextInputEditText etLocation;
+
+        public static EditTextPreferenceDialog newInstance(String key) {
+            final EditTextPreferenceDialog
+                fragment = new EditTextPreferenceDialog();
+            final Bundle b = new Bundle(1);
+            b.putString(ARG_KEY, key);
+            fragment.setArguments(b);
+            return fragment;
+        }
+
+
+        @Override
+        protected void onBindDialogView(View view) {
+            etLocation = view.findViewById(R.id.et_location_preference);
+            etLocation.setText(getUploadLocation());
+            etLocation.setSelection(etLocation.getText().length());
+
+        }
+
+        private String getUploadLocation() {
+            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            return preferences.getString(getString(R.string.preference_key_upload_location), null);
+        }
+
+        private void setUploadLocation(String location) {
+
+            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            if (location.isEmpty()) {
+                getPreference().setSummary(getString(R.string.preference_summary_location));
+            } else {
+                setUploadLocationSummary(location);
+            }
+            preferences.edit().putString(getString(R.string.preference_key_upload_location), location).apply();
+
+        }
+
+        private void setUploadLocationSummary(String location) {
+            if (!location.isEmpty()) {
+                if (location.length() > 25) {
+                    location = location.substring(0, 21);
+                    location += "...";
+                }
+                getPreference().setSummary(location);
+            }
+        }
+
+        @Override
+        public void onDialogClosed(boolean positiveResult) {
+            if (positiveResult && etLocation != null && etLocation.getText() != null) {
+                setUploadLocation(etLocation.getText().toString());
+            }
+
+        }
+
+
+    }
+
 
     private void tearDownActivity() {
         getActivity().finish();

--- a/src/main/java/org/amahi/anywhere/util/CustomEditTextPreference.java
+++ b/src/main/java/org/amahi/anywhere/util/CustomEditTextPreference.java
@@ -1,0 +1,21 @@
+package org.amahi.anywhere.util;
+
+import android.content.Context;
+
+import androidx.preference.EditTextPreference;
+
+import android.util.AttributeSet;
+
+import org.amahi.anywhere.R;
+
+public class CustomEditTextPreference extends EditTextPreference {
+
+    public CustomEditTextPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setDialogLayoutResource(R.layout.custom_edittext_preference);
+        setNegativeButtonText("Cancel");
+        setPositiveButtonText("OK");
+
+    }
+
+}

--- a/src/main/res/layout/custom_edittext_preference.xml
+++ b/src/main/res/layout/custom_edittext_preference.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_location_preference"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/src/main/res/values-v21/themes.xml
+++ b/src/main/res/values-v21/themes.xml
@@ -21,7 +21,6 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorAccent">@color/accent</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="actionModeBackground">@color/primary_action_mode</item>
         <item name="android:textColorPrimary">@color/primary_text</item>
         <item name="android:textColorSecondary">@color/secondary_text</item>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -28,12 +28,33 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorAccent">@color/accent</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="android:textColorPrimary">@color/primary_text</item>
         <item name="android:textColorSecondary">@color/secondary_text</item>
         <item name="alertDialogStyle">@style/AlertDialogTheme</item>
 
     </style>
+
+    <style name="AppPreferenceTheme" parent="PreferenceThemeOverlay">
+        <item name="android:divider">@color/divider</item>
+        <item name="android:dividerHeight">1dp</item>
+    </style>
+
+    <style name="Theme.Amahi.Settings" parent="Theme.AppCompat.DayNight">
+        <item name="android:divider">@color/divider</item>
+        <item name="android:dividerHeight">1dp</item>
+        <item name="android:actionBarStyle">@style/Theme.Amahi.ActionBar</item>
+        <item name="android:windowBackground">@color/background_primary</item>
+        <item name="android:textColorPrimaryInverse">@color/primary_text_material_light</item>
+        <!--Adding Support for the Support Library-->
+        <item name="actionBarStyle">@style/Theme.Amahi.ActionBar</item>
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primary_dark</item>
+        <item name="colorAccent">@color/accent</item>
+        <item name="android:textColorPrimary">@color/primary_text</item>
+        <item name="android:textColorSecondary">@color/secondary_text</item>
+
+    </style>
+
 
     <style name="Theme.Amahi.Fullscreen.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
         <item name="android:background">@color/background_transparent_primary</item>
@@ -54,7 +75,7 @@
         <item name="windowActionBarOverlay">true</item>
     </style>
 
-    <style name="AlertDialogTheme" parent="Theme.AppCompat.Dialog">
+    <style name="AlertDialogTheme" parent="Theme.AppCompat.DayNight.Dialog">
         <item name="android:background">@color/background_secondary</item>
         <item name="colorAccent">@color/accent</item>
         <item name="android:textColor">@color/primary_text</item>

--- a/src/main/res/xml/upload_settings.xml
+++ b/src/main/res/xml/upload_settings.xml
@@ -31,7 +31,7 @@
         android:summary="@string/preference_summary_share"
         android:title="@string/preference_title_upload_share" />
 
-    <EditTextPreference
+    <org.amahi.anywhere.util.CustomEditTextPreference
         android:defaultValue="/"
         android:inputType="text"
         android:key="@string/preference_key_upload_location"


### PR DESCRIPTION
Fixes #466 

Changes made:
1. Currently, the SettingsFragment is recreated on screen rotation since it is initialised in onCreate method of SettingsActivity. So it is fixed by checking if saveInstanceState is null. This fixes the disappearing of Connection dialog and AutoUploadPhotos on screen rotation.
2. For sign out dialog, as it is an AlertDialog, it is changed to use AlertDialogFragment that extends DialogFragment, hence the dialog persists on screen rotation.
3. The deprecated PreferenceFragment class in SettingsFragment is replaced with PreferenceFragmentCompat. This resulted in a bug with the location EditTextPreference in the UploadSettingsFragment, solved it by creating a CustomEditTextPreference.