### PR TITLE
Fix: Unable to make HTTP requests in Android Pie

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -54,6 +54,7 @@
         android:label="@string/application_name"
         android:resizeableActivity="true"
         android:theme="@style/Theme.Amahi"
+        android:usesCleartextTraffic="true"
         tools:ignore="GoogleAppIndexingWarning">
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION
Fixes #481 

**Changes:**
Using usesCleartextTraffic attribute to allow HTTP for all requests solves this issue.