### PR TITLE
Application Crash Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ signing.properties
 amahi-release-key.keystore
 
 .DS*
+
+# Acra
+acra.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: android
 
 before_install:
     - yes | sdkmanager "platforms;android-28"
+    - yes | sdkmanager "platforms;android-29"
+    - yes | sdkmanager "platforms;android-26"
+    - yes | sdkmanager "platforms;android-19"
+"
 
 jdk:
  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Enter your personal email in place of `myemail@mydomain.com`
 
   ```
   $ ./gradlew clean assembleDebug
-
   ```
 
 4. Once you have built the application, you will be needing credentials to use the application. Go to Amahi website and create your account, once the account is activated, you will see the description on how to set up the Amahi server. However, this is not strictly needed, as we have a set up of a demo server called "Welcome to Amahi" which you should see even without your own server installed.

--- a/README.md
+++ b/README.md
@@ -22,16 +22,25 @@ You will need JDK 1.7+ installed to work with it. Gradle, Android SDK, and proje
 
 This is something to keep **private** and you obtain it by sending a message to `support at Amahi dot org`.
 
+2. Set ACRA information
 
-2. Build the application using a command line or using GUI.
+  ```
+  $ vim acra.properties
+  ```
+  ```
+  mailto.email = myemail@mydomain.com
+  ```
+
+Enter your personal email in place of `myemail@mydomain.com`
+
+3. Build the application using a command line or using GUI.
 
   ```
   $ ./gradlew clean assembleDebug
 
   ```
 
-
-3. Once you have built the application, you will be needing credentials to use the application. Go to Amahi website and create your account, once the account is activated, you will see the description on how to set up the Amahi server. However, this is not strictly needed, as we have a set up of a demo server called "Welcome to Amahi" which you should see even without your own server installed.
+4. Once you have built the application, you will be needing credentials to use the application. Go to Amahi website and create your account, once the account is activated, you will see the description on how to set up the Amahi server. However, this is not strictly needed, as we have a set up of a demo server called "Welcome to Amahi" which you should see even without your own server installed.
 
 ## Code Style Convention
 

--- a/acra.properties.sample
+++ b/acra.properties.sample
@@ -1,0 +1,4 @@
+# Set ACRA mailing information in acra.properties.
+# This is something to keep private and can be created by following steps in README.md
+
+mailto.email = myemail@mydomain.com

--- a/build.gradle
+++ b/build.gradle
@@ -52,10 +52,12 @@ android {
         targetSdkVersion 28
 
         def apiFile = file("api.properties")
+        def acraFile = file("acra.properties")
         def apiProperties = new Properties()
+        def acraProperties = new Properties()
 
-        // NOTE-cpg: this fake api is here for the tests to pass
         def fakeApiFile = file("fakeApi.properties")
+        def fakeAcraFile = file("fakeAcra.properties")
 
         if (apiFile.exists()) {
             apiProperties.load(apiFile.newInputStream())
@@ -63,11 +65,18 @@ android {
             apiProperties.load(fakeApiFile.newInputStream())
         }
 
+        if (acraFile.exists()) {
+            acraProperties.load(acraFile.newInputStream())
+        } else {
+            acraProperties.load(fakeAcraFile.newInputStream())
+        }
+
         buildConfigField "String", "API_URL_AMAHI", formatStringField(apiProperties["url.amahi"])
         buildConfigField "String", "API_URL_PROXY", formatStringField(apiProperties["url.proxy"])
         buildConfigField "String", "API_CLIENT_ID", formatStringField(apiProperties["client.id"])
         buildConfigField "String", "API_CLIENT_SECRET", formatStringField(apiProperties["client.secret"])
         buildConfigField "String", "CHROMECAST_APP_ID", formatStringField(apiProperties["chromecast.app.id"])
+        buildConfigField "String", "ACRA_EMAIL", formatStringField(acraProperties["mailto.email"])
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -88,8 +97,8 @@ android {
         }
     }
     compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
     }
 }
 
@@ -170,6 +179,12 @@ dependencies {
 
     implementation 'android.arch.persistence.room:runtime:' + rootProject.archRoomVersion
     annotationProcessor 'android.arch.persistence.room:compiler:' + rootProject.archRoomVersion
+
+    def acraVersion = '5.6.1'
+    implementation "ch.acra:acra-mail:$acraVersion"
+    implementation "ch.acra:acra-dialog:$acraVersion"
+    implementation "ch.acra:acra-notification:$acraVersion"
+    implementation "ch.acra:acra-toast:$acraVersion"
 
     // Uncomment the dependencies below to enable Chuck Interceptor for logging
 /*

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'io.fabric.tools:gradle:1.26.1'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'io.fabric.tools:gradle:1.26.1'
+        classpath 'io.fabric.tools:gradle:1.28.1'
     }
 }
 

--- a/fakeAcra.properties
+++ b/fakeAcra.properties
@@ -1,0 +1,4 @@
+# Set ACRA mailing information in acra.properties.
+# This is something to keep private and can be created by following steps in README.md
+
+mailto.email = myemail@mydomain.com

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jun 09 01:34:57 IST 2019
+#Sat Jul 18 05:49:07 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -33,6 +33,11 @@ import androidx.appcompat.app.AppCompatDelegate;
 
 import com.crashlytics.android.Crashlytics;
 
+import org.acra.ACRA;
+import org.acra.ReportField;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.MailSenderConfigurationBuilder;
+import org.acra.data.StringFormat;
 import org.amahi.anywhere.job.NetConnectivityJob;
 import org.amahi.anywhere.job.PhotosContentJob;
 import org.amahi.anywhere.server.Api;
@@ -173,23 +178,23 @@ public class AmahiApplication extends Application {
         super.attachBaseContext(base);
         if (isDebugging()) {
 
-//            CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
-//                .setBuildConfigClass(BuildConfig.class)
-//                .setReportFormat(StringFormat.JSON)
-//                .setAlsoReportToAndroidFramework(true)
-//                .setReportContent(ReportField.APP_VERSION_CODE)
-//                .setReportContent(ReportField.APP_VERSION_NAME)
-//                .setReportContent(ReportField.ANDROID_VERSION)
-//                .setReportContent(ReportField.PHONE_MODEL)
-//                .setReportContent(ReportField.CUSTOM_DATA)
-//                .setReportContent(ReportField.STACK_TRACE)
-//                .setReportContent(ReportField.LOGCAT)
-//                .setResReportSendSuccessToast(R.string.acra_report_toast);
-//
-//            builder.getPluginConfigurationBuilder(MailSenderConfigurationBuilder.class)
-//                .setMailTo(Api.getAcraEmail());
-//
-//            ACRA.init(this, builder);
+            CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
+                .setBuildConfigClass(BuildConfig.class)
+                .setReportFormat(StringFormat.JSON)
+                .setAlsoReportToAndroidFramework(true)
+                .setReportContent(ReportField.APP_VERSION_CODE)
+                .setReportContent(ReportField.APP_VERSION_NAME)
+                .setReportContent(ReportField.ANDROID_VERSION)
+                .setReportContent(ReportField.PHONE_MODEL)
+                .setReportContent(ReportField.CUSTOM_DATA)
+                .setReportContent(ReportField.STACK_TRACE)
+                .setReportContent(ReportField.LOGCAT)
+                .setResReportSendSuccessToast(R.string.acra_report_toast);
+
+            builder.getPluginConfigurationBuilder(MailSenderConfigurationBuilder.class)
+                .setMailTo(Api.getAcraEmail());
+
+            ACRA.init(this, builder);
         }
     }
 }

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -27,6 +27,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.StrictMode;
 import android.preference.PreferenceManager;
+
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatDelegate;
 
@@ -34,6 +35,7 @@ import com.crashlytics.android.Crashlytics;
 
 import org.amahi.anywhere.job.NetConnectivityJob;
 import org.amahi.anywhere.job.PhotosContentJob;
+import org.amahi.anywhere.server.Api;
 
 import dagger.ObjectGraph;
 import io.fabric.sdk.android.Fabric;
@@ -43,6 +45,7 @@ import timber.log.Timber;
  * Application declaration. Basically sets things up at the startup time,
  * such as dependency injection, logging, crash reporting and possible ANR detecting.
  */
+
 public class AmahiApplication extends Application {
     private ObjectGraph injector;
 
@@ -165,4 +168,28 @@ public class AmahiApplication extends Application {
 
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        if (isDebugging()) {
+
+//            CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
+//                .setBuildConfigClass(BuildConfig.class)
+//                .setReportFormat(StringFormat.JSON)
+//                .setAlsoReportToAndroidFramework(true)
+//                .setReportContent(ReportField.APP_VERSION_CODE)
+//                .setReportContent(ReportField.APP_VERSION_NAME)
+//                .setReportContent(ReportField.ANDROID_VERSION)
+//                .setReportContent(ReportField.PHONE_MODEL)
+//                .setReportContent(ReportField.CUSTOM_DATA)
+//                .setReportContent(ReportField.STACK_TRACE)
+//                .setReportContent(ReportField.LOGCAT)
+//                .setResReportSendSuccessToast(R.string.acra_report_toast);
+//
+//            builder.getPluginConfigurationBuilder(MailSenderConfigurationBuilder.class)
+//                .setMailTo(Api.getAcraEmail());
+//
+//            ACRA.init(this, builder);
+        }
+    }
 }

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -170,7 +170,6 @@ public class AmahiApplication extends Application {
         NotificationManager notificationManager = getSystemService(NotificationManager.class);
         notificationManager.createNotificationChannel(uploadChannel);
         notificationManager.createNotificationChannel(downloadChannel);
-
     }
 
     @Override

--- a/src/main/java/org/amahi/anywhere/server/Api.java
+++ b/src/main/java/org/amahi/anywhere/server/Api.java
@@ -43,4 +43,8 @@ public final class Api {
     public static String getClientSecret() {
         return BuildConfig.API_CLIENT_SECRET;
     }
+
+    public static String getAcraEmail() {
+        return BuildConfig.ACRA_EMAIL;
+    }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -320,4 +320,6 @@
     <string name="pref_option_go_back">Go back</string>
     <string name="pref_connection_desc">Select the type of connection you want. You can set it as Auto detect, remote or local area network.</string>
 
+    <string name="acra_report_toast" translatable="false">ACRA Log Report Sent!</string>
+
 </resources>


### PR DESCRIPTION
Adding Support for ACRA (https://github.com/ACRA/acra) which will provide crash logs to developers via email whenever the app crashes.
This logging will happen only in the `debug` mode. It can be easily modified to support `release` mode too. Developers will have to enter their preferred email in `acra.properties` file.