### PR TITLE
Add Custom Tabs to WebView

### DIFF
--- a/src/main/java/org/amahi/anywhere/AmahiModule.java
+++ b/src/main/java/org/amahi/anywhere/AmahiModule.java
@@ -33,6 +33,7 @@ import org.amahi.anywhere.activity.ServerFileImageActivity;
 import org.amahi.anywhere.activity.ServerFileVideoActivity;
 import org.amahi.anywhere.activity.ServerFileWebActivity;
 import org.amahi.anywhere.activity.ServerFilesActivity;
+import org.amahi.anywhere.activity.WebViewActivity;
 import org.amahi.anywhere.cache.CacheModule;
 import org.amahi.anywhere.fragment.AudioListFragment;
 import org.amahi.anywhere.fragment.NavigationFragment;
@@ -99,6 +100,7 @@ import dagger.Provides;
         VideoService.class,
         MainTVFragment.class,
         TVWebViewActivity.class,
+        WebViewActivity.class,
         ServerFileTvFragment.class,
         UploadService.class,
         DownloadService.class,

--- a/src/main/java/org/amahi/anywhere/activity/ServerFileWebActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFileWebActivity.java
@@ -112,6 +112,7 @@ public class ServerFileWebActivity extends AppCompatActivity {
         CustomTabsClient.bindCustomTabsService(this, getPackageName(), mCustomTabsServiceConnection);
 
         mCustomTabsIntent = new CustomTabsIntent.Builder(mCustomTabsSession)
+            .setToolbarColor(getResources().getColor(R.color.primary))
             .setShowTitle(true)
             .build();
 

--- a/src/main/java/org/amahi/anywhere/activity/WebViewActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/WebViewActivity.java
@@ -1,59 +1,73 @@
 package org.amahi.anywhere.activity;
 
+import android.content.ComponentName;
 import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
-import android.view.MenuItem;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
 
+import org.amahi.anywhere.AmahiApplication;
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.util.LocaleHelper;
 
 public class WebViewActivity extends AppCompatActivity {
 
-    private WebView webView;
+    private static final String amahiURL = "https://www.amahi.org/android";
+
+    CustomTabsClient mCustomTabsClient;
+    CustomTabsSession mCustomTabsSession;
+    CustomTabsServiceConnection mCustomTabsServiceConnection;
+    CustomTabsIntent mCustomTabsIntent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setUpHomeNavigation();
         setContentView(R.layout.activity_web_view);
-        webView = findViewById(R.id.webview);
 
-        loadWebView("https://www.amahi.org/android");
+        setUpInjections();
 
-    }
-
-    private void loadWebView(String url) {
-        webView.setWebViewClient(new WebViewClient());
-
-        WebSettings settings = webView.getSettings();
-
-        settings.setLoadWithOverviewMode(true);
-        settings.setBuiltInZoomControls(true);
-        settings.setUseWideViewPort(true);
-
-        webView.loadUrl(url);
+        setUpCustomTabs(amahiURL);
 
     }
 
-    private void setUpHomeNavigation() {
-        getSupportActionBar().setHomeButtonEnabled(true);
+    private void setUpInjections() {
+        AmahiApplication.from(this).inject(this);
+    }
+
+    private void setUpCustomTabs(String url) {
+
+        mCustomTabsServiceConnection = new CustomTabsServiceConnection() {
+            @Override
+            public void onCustomTabsServiceConnected(ComponentName componentName, CustomTabsClient customTabsClient) {
+                mCustomTabsClient = customTabsClient;
+                mCustomTabsClient.warmup(0L);
+                mCustomTabsSession = mCustomTabsClient.newSession(null);
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName name) {
+                mCustomTabsClient = null;
+            }
+        };
+
+        CustomTabsClient.bindCustomTabsService(this, getPackageName(), mCustomTabsServiceConnection);
+
+        mCustomTabsIntent = new CustomTabsIntent.Builder(mCustomTabsSession)
+            .setShowTitle(true)
+            .build();
+
+        mCustomTabsIntent.launchUrl(this, Uri.parse(url));
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem menuItem) {
-        switch (menuItem.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-
-            default:
-                return super.onOptionsItemSelected(menuItem);
-        }
+    protected void onResume() {
+        super.onResume();
+        onBackPressed();
     }
 
     @Override

--- a/src/main/java/org/amahi/anywhere/activity/WebViewActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/WebViewActivity.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2014 Amahi
+ *
+ * This file is part of Amahi.
+ *
+ * Amahi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Amahi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
+ */
+
 package org.amahi.anywhere.activity;
 
 import android.content.ComponentName;
@@ -12,11 +31,10 @@ import androidx.browser.customtabs.CustomTabsSession;
 
 import org.amahi.anywhere.AmahiApplication;
 import org.amahi.anywhere.R;
+import org.amahi.anywhere.util.Constants;
 import org.amahi.anywhere.util.LocaleHelper;
 
 public class WebViewActivity extends AppCompatActivity {
-
-    private static final String amahiURL = "https://www.amahi.org/android";
 
     CustomTabsClient mCustomTabsClient;
     CustomTabsSession mCustomTabsSession;
@@ -31,7 +49,7 @@ public class WebViewActivity extends AppCompatActivity {
 
         setUpInjections();
 
-        setUpCustomTabs(amahiURL);
+        setUpCustomTabs(Constants.amahiAndroidUrl);
 
     }
 
@@ -59,6 +77,7 @@ public class WebViewActivity extends AppCompatActivity {
 
         mCustomTabsIntent = new CustomTabsIntent.Builder(mCustomTabsSession)
             .setShowTitle(true)
+            .setToolbarColor(getResources().getColor(R.color.primary))
             .build();
 
         mCustomTabsIntent.launchUrl(this, Uri.parse(url));

--- a/src/main/java/org/amahi/anywhere/util/Constants.java
+++ b/src/main/java/org/amahi/anywhere/util/Constants.java
@@ -42,4 +42,6 @@ public class Constants {
     public static final String successIntentExtra = "success";
 
     public static final String sharesPathAppendLoc = "shares";
+
+    public static final String amahiAndroidUrl = "https://www.amahi.org/android";
 }

--- a/src/main/res/layout/activity_server_file_web.xml
+++ b/src/main/res/layout/activity_server_file_web.xml
@@ -22,4 +22,4 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:inAnimation="@android:anim/fade_in"
-    android:outAnimation="@android:anim/fade_out"></ViewAnimator>
+    android:outAnimation="@android:anim/fade_out"/>

--- a/src/main/res/layout/activity_web_view.xml
+++ b/src/main/res/layout/activity_web_view.xml
@@ -1,16 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/activity_main"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/background_secondary"
-    tools:context="org.amahi.anywhere.activity.WebViewActivity">
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2014 Amahi
+  ~
+  ~ This file is part of Amahi.
+  ~
+  ~ Amahi is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Amahi is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Amahi. If not, see <http ://www.gnu.org/licenses/>.
+  -->
 
-    <ViewAnimator xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/animator"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:inAnimation="@android:anim/fade_in"
-        android:outAnimation="@android:anim/fade_out"></ViewAnimator>
-</RelativeLayout>
+
+<ViewAnimator xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/animator"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:inAnimation="@android:anim/fade_in"
+    android:outAnimation="@android:anim/fade_out"/>

--- a/src/main/res/layout/activity_web_view.xml
+++ b/src/main/res/layout/activity_web_view.xml
@@ -7,17 +7,10 @@
     android:background="@color/background_secondary"
     tools:context="org.amahi.anywhere.activity.WebViewActivity">
 
-    <WebView
-        android:id="@+id/webview"
+    <ViewAnimator xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/animator"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:background="@color/background_secondary" />
-
-    <ProgressBar
-        android:id="@+id/progress_webview"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:layout_gravity="center"
-        android:visibility="gone" />
+        android:inAnimation="@android:anim/fade_in"
+        android:outAnimation="@android:anim/fade_out"></ViewAnimator>
 </RelativeLayout>


### PR DESCRIPTION
Added support for Custom Tabs in the webview for Version which is the new standard for showing URLs inside the app without the heavy lifting of opening the whole browser. The SVG/HTML files are also displayed in a webview at the moment.

https://developers.google.com/web/android/custom-tabs
![image](https://user-images.githubusercontent.com/31701616/88487988-d350d700-cfa7-11ea-8d93-fd0199863055.png)

