### PR TITLE
Added Last Opened Display of Files Feature

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/ServerFileAudioActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFileAudioActivity.java
@@ -62,8 +62,10 @@ import org.amahi.anywhere.bus.AudioControlPreviousEvent;
 import org.amahi.anywhere.bus.AudioMetadataRetrievedEvent;
 import org.amahi.anywhere.bus.AudioPreparedEvent;
 import org.amahi.anywhere.bus.BusProvider;
+import org.amahi.anywhere.db.entities.FileInfo;
 import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.entities.RecentFile;
+import org.amahi.anywhere.db.repositories.FileInfoRepository;
 import org.amahi.anywhere.db.repositories.OfflineFileRepository;
 import org.amahi.anywhere.db.repositories.RecentFileRepository;
 import org.amahi.anywhere.fragment.AudioListFragment;
@@ -74,6 +76,7 @@ import org.amahi.anywhere.server.model.ServerShare;
 import org.amahi.anywhere.service.AudioService;
 import org.amahi.anywhere.task.AudioMetadataRetrievingTask;
 import org.amahi.anywhere.util.AudioMetadataFormatter;
+import org.amahi.anywhere.util.DateTime;
 import org.amahi.anywhere.util.FileManager;
 import org.amahi.anywhere.util.Fragments;
 import org.amahi.anywhere.util.Intents;
@@ -139,6 +142,7 @@ public class ServerFileAudioActivity extends AppCompatActivity implements
         prepareFiles();
 
         setUpAudio();
+        setUpLastOpened();
 
         if (savedInstanceState != null) {
             audioListVisible = savedInstanceState.getBoolean(AUDIO_LIST_VISIBLE);
@@ -207,6 +211,12 @@ public class ServerFileAudioActivity extends AppCompatActivity implements
 
     private void setUpAudioListener() {
         getAudioPager().addOnPageChangeListener(this);
+    }
+
+    private void setUpLastOpened() {
+        FileInfoRepository fileInfoRepository = new FileInfoRepository(this);
+        FileInfo fileInfo = new FileInfo(getFile().getUniqueKey(), DateTime.getCurrentTime());
+        fileInfoRepository.insert(fileInfo);
     }
 
     @Override

--- a/src/main/java/org/amahi/anywhere/activity/ServerFileImageActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFileImageActivity.java
@@ -48,8 +48,10 @@ import org.amahi.anywhere.adapter.ServerFilesImagePagerAdapter;
 import org.amahi.anywhere.bus.BusProvider;
 import org.amahi.anywhere.bus.FileCopiedEvent;
 import org.amahi.anywhere.bus.FileDownloadedEvent;
+import org.amahi.anywhere.db.entities.FileInfo;
 import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.entities.RecentFile;
+import org.amahi.anywhere.db.repositories.FileInfoRepository;
 import org.amahi.anywhere.db.repositories.OfflineFileRepository;
 import org.amahi.anywhere.db.repositories.RecentFileRepository;
 import org.amahi.anywhere.fragment.PrepareDialogFragment;
@@ -58,6 +60,7 @@ import org.amahi.anywhere.model.FileOption;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;
+import org.amahi.anywhere.util.DateTime;
 import org.amahi.anywhere.util.Downloader;
 import org.amahi.anywhere.util.FileManager;
 import org.amahi.anywhere.util.FullScreenHelper;
@@ -123,6 +126,8 @@ public class ServerFileImageActivity extends AppCompatActivity implements
         setUpCast();
 
         setUpFullScreen();
+
+        setUpLastOpened();
     }
 
     private void prepareFiles() {
@@ -172,6 +177,12 @@ public class ServerFileImageActivity extends AppCompatActivity implements
         if (isCastConnected()) {
             loadRemoteMedia();
         }
+    }
+
+    private void setUpLastOpened() {
+        FileInfoRepository fileInfoRepository = new FileInfoRepository(this);
+        FileInfo fileInfo = new FileInfo(getCurrentFile().getUniqueKey(), DateTime.getCurrentTime());
+        fileInfoRepository.insert(fileInfo);
     }
 
     private void setUpImageTitle() {

--- a/src/main/java/org/amahi/anywhere/activity/ServerFileVideoActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFileVideoActivity.java
@@ -59,8 +59,10 @@ import org.amahi.anywhere.AmahiApplication;
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.bus.BusProvider;
 import org.amahi.anywhere.bus.DialogButtonClickedEvent;
+import org.amahi.anywhere.db.entities.FileInfo;
 import org.amahi.anywhere.db.entities.PlayedFile;
 import org.amahi.anywhere.db.entities.RecentFile;
+import org.amahi.anywhere.db.repositories.FileInfoRepository;
 import org.amahi.anywhere.db.repositories.PlayedFileRepository;
 import org.amahi.anywhere.db.repositories.RecentFileRepository;
 import org.amahi.anywhere.fragment.ResumeDialogFragment;
@@ -68,6 +70,7 @@ import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;
 import org.amahi.anywhere.service.VideoService;
+import org.amahi.anywhere.util.DateTime;
 import org.amahi.anywhere.util.FileManager;
 import org.amahi.anywhere.util.FullScreenHelper;
 import org.amahi.anywhere.util.Intents;
@@ -142,6 +145,8 @@ public class ServerFileVideoActivity extends AppCompatActivity implements
 
         setUpVideo();
 
+        setUpLastOpened();
+
         loadState(savedInstanceState);
     }
 
@@ -215,6 +220,12 @@ public class ServerFileVideoActivity extends AppCompatActivity implements
             videoControls.toggle();
         });
         fullScreen.init();
+    }
+
+    private void setUpLastOpened() {
+        FileInfoRepository fileInfoRepository = new FileInfoRepository(this);
+        FileInfo fileInfo = new FileInfo(getVideoFile().getUniqueKey(), DateTime.getCurrentTime());
+        fileInfoRepository.insert(fileInfo);
     }
 
     private FrameLayout getSwipeContainer() {

--- a/src/main/java/org/amahi/anywhere/activity/ServerFileWebActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFileWebActivity.java
@@ -31,9 +31,12 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import org.amahi.anywhere.AmahiApplication;
 import org.amahi.anywhere.R;
+import org.amahi.anywhere.db.entities.FileInfo;
+import org.amahi.anywhere.db.repositories.FileInfoRepository;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerFile;
 import org.amahi.anywhere.server.model.ServerShare;
+import org.amahi.anywhere.util.DateTime;
 import org.amahi.anywhere.util.Intents;
 import org.amahi.anywhere.util.LocaleHelper;
 
@@ -77,6 +80,8 @@ public class ServerFileWebActivity extends AppCompatActivity {
         setUpInjections();
 
         setUpWebResource(savedInstanceState);
+
+        setUpLastOpened();
     }
 
     private void setUpInjections() {
@@ -116,6 +121,12 @@ public class ServerFileWebActivity extends AppCompatActivity {
             .build();
 
         mCustomTabsIntent.launchUrl(this, getWebResourceUri());
+    }
+
+    private void setUpLastOpened() {
+        FileInfoRepository fileInfoRepository = new FileInfoRepository(this);
+        FileInfo fileInfo = new FileInfo(getFile().getUniqueKey(), DateTime.getCurrentTime());
+        fileInfoRepository.insert(fileInfo);
     }
 
     private boolean isWebResourceStateValid(Bundle state) {

--- a/src/main/java/org/amahi/anywhere/bus/FileOptionClickEvent.java
+++ b/src/main/java/org/amahi/anywhere/bus/FileOptionClickEvent.java
@@ -4,13 +4,19 @@ import org.amahi.anywhere.model.FileOption;
 
 public class FileOptionClickEvent {
     private int fileOption;
+    private String uniqueKey;
 
-    public FileOptionClickEvent(@FileOption.Types int fileOption) {
+    public FileOptionClickEvent(@FileOption.Types int fileOption, String uniqueKey) {
         this.fileOption = fileOption;
+        this.uniqueKey = uniqueKey;
     }
 
     @FileOption.Types
     public int getFileOption() {
         return fileOption;
+    }
+
+    public String getFileUniqueKey() {
+        return uniqueKey;
     }
 }

--- a/src/main/java/org/amahi/anywhere/db/AppDatabase.java
+++ b/src/main/java/org/amahi/anywhere/db/AppDatabase.java
@@ -4,16 +4,20 @@ package org.amahi.anywhere.db;
 import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.Context;
 
+import org.amahi.anywhere.db.daos.FileInfoDao;
 import org.amahi.anywhere.db.daos.OfflineFileDao;
 import org.amahi.anywhere.db.daos.PlayedFileDao;
 import org.amahi.anywhere.db.daos.RecentFileDao;
+import org.amahi.anywhere.db.entities.FileInfo;
 import org.amahi.anywhere.db.entities.OfflineFile;
 import org.amahi.anywhere.db.entities.PlayedFile;
 import org.amahi.anywhere.db.entities.RecentFile;
 
-@Database(entities = {OfflineFile.class, PlayedFile.class, RecentFile.class}, version = 1, exportSchema = false)
+@Database(entities = {OfflineFile.class, PlayedFile.class, RecentFile.class, FileInfo.class}, version = 2, exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase {
 
     private static AppDatabase INSTANCE;
@@ -23,6 +27,7 @@ public abstract class AppDatabase extends RoomDatabase {
             INSTANCE = Room.databaseBuilder(context.getApplicationContext(),
                 AppDatabase.class, "app_database")
                 .allowMainThreadQueries()
+                .addMigrations(MIGRATION_1_2)
                 .build();
         }
         return INSTANCE;
@@ -38,4 +43,15 @@ public abstract class AppDatabase extends RoomDatabase {
 
     public abstract PlayedFileDao playedFileDao();
 
+    public abstract FileInfoDao fileInfoDao();
+
+    //migrations
+
+    static final Migration MIGRATION_1_2 = new Migration(1, 2) {
+        @Override
+        public void migrate(SupportSQLiteDatabase database) {
+            database.execSQL("CREATE TABLE `file_info_table` (`uniqueKey` TEXT NOT NULL, "
+                + "`lastOpened` TEXT, PRIMARY KEY(`uniqueKey`))");
+        }
+    };
 }

--- a/src/main/java/org/amahi/anywhere/db/daos/FileInfoDao.java
+++ b/src/main/java/org/amahi/anywhere/db/daos/FileInfoDao.java
@@ -1,0 +1,24 @@
+package org.amahi.anywhere.db.daos;
+
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import org.amahi.anywhere.db.entities.FileInfo;
+
+@Dao
+public interface FileInfoDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(FileInfo fileInfo);
+
+    @Update
+    void update(FileInfo fileInfo);
+
+    @Query("SELECT * FROM file_info_table where uniqueKey = :uniqueKey")
+    FileInfo getFileInfo(String uniqueKey);
+
+
+}

--- a/src/main/java/org/amahi/anywhere/db/entities/FileInfo.java
+++ b/src/main/java/org/amahi/anywhere/db/entities/FileInfo.java
@@ -1,0 +1,36 @@
+package org.amahi.anywhere.db.entities;
+
+import androidx.annotation.NonNull;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "file_info_table")
+public class FileInfo {
+
+    @PrimaryKey
+    @NonNull
+    private String uniqueKey;
+
+    private String lastOpened;
+
+    public FileInfo(String uniqueKey, String lastOpened) {
+        this.uniqueKey = uniqueKey;
+        this.lastOpened = lastOpened;
+    }
+
+    public String getUniqueKey() {
+        return uniqueKey;
+    }
+
+    public void setUniqueKey(String uniqueKey) {
+        this.uniqueKey = uniqueKey;
+    }
+
+    public String getLastOpened() {
+        return lastOpened;
+    }
+
+    public void setLastOpened(String lastOpened) {
+        this.lastOpened = lastOpened;
+    }
+}

--- a/src/main/java/org/amahi/anywhere/db/repositories/FileInfoRepository.java
+++ b/src/main/java/org/amahi/anywhere/db/repositories/FileInfoRepository.java
@@ -1,0 +1,32 @@
+package org.amahi.anywhere.db.repositories;
+
+import android.content.Context;
+
+import org.amahi.anywhere.db.AppDatabase;
+import org.amahi.anywhere.db.daos.FileInfoDao;
+import org.amahi.anywhere.db.entities.FileInfo;
+
+public class FileInfoRepository {
+
+    private FileInfoDao fileInfoDao;
+
+    public FileInfoRepository(Context context) {
+        AppDatabase db = AppDatabase.getDatabase(context);
+        fileInfoDao = db.fileInfoDao();
+
+    }
+
+    public FileInfo getFileInfo(String uniqueKey) {
+        return fileInfoDao.getFileInfo(uniqueKey);
+    }
+
+    public void insert(FileInfo fileInfo) {
+        fileInfoDao.insert(fileInfo);
+    }
+
+    public void update(FileInfo fileInfo) {
+        fileInfoDao.update(fileInfo);
+    }
+
+
+}

--- a/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/AlertDialogFragment.java
@@ -11,8 +11,11 @@ import android.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
 
 import org.amahi.anywhere.R;
+import org.amahi.anywhere.db.repositories.FileInfoRepository;
 import org.amahi.anywhere.util.Fragments;
 
 import java.io.File;
@@ -20,10 +23,13 @@ import java.io.File;
 public class AlertDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
     File file;
     private int dialogType = -1;
+    private String fileUniqueKey;
     AlertDialog.Builder builder;
     public static final int DELETE_FILE_DIALOG = 0;
     public static final int DUPLICATE_FILE_DIALOG = 1;
-    public static final int SIGN_OUT_DIALOG = 2;
+    public static final int SIGN_OUT_DIALOG = 3;
+    public static final int FILE_INFO_DIALOG = 2;
+    public static final String LAST_OPENED_NULL = "Never opened";
 
 
     @NonNull
@@ -34,6 +40,7 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
 
         if (getArguments() != null) {
             dialogType = getArguments().getInt(Fragments.Arguments.DIALOG_TYPE);
+            fileUniqueKey = getArguments().getString(Fragments.Arguments.FILE_UNIQUE_KEY);
         }
 
         switch (dialogType) {
@@ -43,6 +50,10 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
 
             case DUPLICATE_FILE_DIALOG:
                 buildDuplicateDialog();
+                break;
+
+            case FILE_INFO_DIALOG:
+                buildFileInfoDialog();
                 break;
 
             case SIGN_OUT_DIALOG:
@@ -65,6 +76,22 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
             .setMessage(getString(R.string.message_duplicate_file_upload_body, file.getName()))
             .setPositiveButton(getString(R.string.button_yes), this)
             .setNegativeButton(getString(R.string.button_no), this);
+    }
+    private void buildFileInfoDialog() {
+        View view = getActivity().getLayoutInflater().inflate(R.layout.file_info_dialog, null);
+        TextView lastOpened = view.findViewById(R.id.text_last_opened);
+        lastOpened.setText(getFileLastOpened());
+        builder.setTitle(getString(R.string.title_file_info))
+            .setPositiveButton(getString(R.string.text_ok), this);
+        builder.setView(view);
+    }
+
+    private String getFileLastOpened() {
+        FileInfoRepository fileInfoRepository = new FileInfoRepository(getContext());
+        if (fileInfoRepository.getFileInfo(fileUniqueKey) == null) {
+            return LAST_OPENED_NULL;
+        }
+        return fileInfoRepository.getFileInfo(fileUniqueKey).getLastOpened();
     }
 
     private void buildSignOutDialog() {

--- a/src/main/java/org/amahi/anywhere/fragment/FileOptionsDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/FileOptionsDialogFragment.java
@@ -38,10 +38,14 @@ public class FileOptionsDialogFragment extends BottomSheetDialogFragment {
         LinearLayout deleteLayout = view.findViewById(R.id.delete_layout);
         LinearLayout downloadLayout = view.findViewById(R.id.download_layout);
         LinearLayout offlineLayout = view.findViewById(R.id.offline_layout);
+        LinearLayout fileInfoLayout = view.findViewById(R.id.file_info_layout);
 
-        shareLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.SHARE));
-        deleteLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.DELETE));
-        downloadLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.DOWNLOAD));
+        String uniqueKey = getFileUniqueKey();
+
+        shareLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.SHARE, uniqueKey));
+        deleteLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.DELETE, uniqueKey));
+        downloadLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.DOWNLOAD, uniqueKey));
+        fileInfoLayout.setOnClickListener(v -> setOptionAndDismiss(FileOption.FILE_INFO, uniqueKey));
 
         if (!isOfflineFragment()) {
             SwitchCompat offlineSwitch = view.findViewById(R.id.offline_switch);
@@ -52,9 +56,9 @@ public class FileOptionsDialogFragment extends BottomSheetDialogFragment {
 
                 offlineSwitch.setOnCheckedChangeListener((compoundButton, b) -> {
                     if (b) {
-                        setOption(FileOption.OFFLINE_ENABLED);
+                        setOption(FileOption.OFFLINE_ENABLED, uniqueKey);
                     } else {
-                        setOption(FileOption.OFFLINE_DISABLED);
+                        setOption(FileOption.OFFLINE_DISABLED, uniqueKey);
                     }
                     file.setOffline(b);
                     getArguments().putParcelable(Fragments.Arguments.SERVER_FILE, file);
@@ -67,16 +71,21 @@ public class FileOptionsDialogFragment extends BottomSheetDialogFragment {
         }
     }
 
+    private String getFileUniqueKey() {
+        ServerFile file = getArguments().getParcelable(Fragments.Arguments.SERVER_FILE);
+        return file.getUniqueKey();
+    }
+
     private boolean isOfflineFragment() {
         return getArguments().getBoolean(Fragments.Arguments.IS_OFFLINE_FRAGMENT);
     }
 
-    public void setOption(@FileOption.Types int type) {
-        BusProvider.getBus().post(new FileOptionClickEvent(type));
+    public void setOption(@FileOption.Types int type, String uniqueKey) {
+        BusProvider.getBus().post(new FileOptionClickEvent(type, uniqueKey));
     }
 
-    public void setOptionAndDismiss(@FileOption.Types int type) {
-        setOption(type);
+    public void setOptionAndDismiss(@FileOption.Types int type, String uniqueKey) {
+        setOption(type, uniqueKey);
         dismiss();
     }
 }

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -241,6 +241,7 @@ public class ServerFilesFragment extends Fragment implements
     @Subscribe
     public void onFileOptionSelected(FileOptionClickEvent event) {
         selectedFileOption = event.getFileOption();
+        String uniqueKey = event.getFileUniqueKey();
         switch (selectedFileOption) {
             case FileOption.DOWNLOAD:
                 if (Android.isPermissionRequired()) {
@@ -268,6 +269,10 @@ public class ServerFilesFragment extends Fragment implements
                 break;
             case FileOption.OFFLINE_DISABLED:
                 changeOfflineState(false);
+
+            case FileOption.FILE_INFO:
+                showFileInfo(uniqueKey);
+
         }
     }
 
@@ -436,6 +441,16 @@ public class ServerFilesFragment extends Fragment implements
         } else {
             Toast.makeText(getContext(), R.string.message_delete_file_error, Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private void showFileInfo(String uniqueKey) {
+        AlertDialogFragment fileInfoDialog = new AlertDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt(Fragments.Arguments.DIALOG_TYPE, AlertDialogFragment.FILE_INFO_DIALOG);
+        bundle.putSerializable("file_unique_key", uniqueKey);
+        fileInfoDialog.setArguments(bundle);
+        fileInfoDialog.setTargetFragment(this, 2);
+        fileInfoDialog.show(getFragmentManager(), "file_info_dialog");
     }
 
     private ServerFile getCheckedFile() {

--- a/src/main/java/org/amahi/anywhere/model/FileOption.java
+++ b/src/main/java/org/amahi/anywhere/model/FileOption.java
@@ -10,6 +10,7 @@ public class FileOption {
     public static final int DELETE = 3;
     public static final int OFFLINE_DISABLED = 4;
     public static final int OFFLINE_ENABLED = 5;
+    public static final int FILE_INFO = 6;
     @Types
     private int type;
 
@@ -22,7 +23,7 @@ public class FileOption {
         return type;
     }
 
-    @IntDef({OPEN, SHARE, DOWNLOAD, DELETE, OFFLINE_DISABLED, OFFLINE_ENABLED})
+    @IntDef({OPEN, SHARE, DOWNLOAD, DELETE, OFFLINE_DISABLED, OFFLINE_ENABLED, FILE_INFO})
     public @interface Types {
     }
 }

--- a/src/main/java/org/amahi/anywhere/util/DateTime.java
+++ b/src/main/java/org/amahi/anywhere/util/DateTime.java
@@ -1,0 +1,14 @@
+package org.amahi.anywhere.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+public class DateTime {
+
+    public static String getCurrentTime() {
+        Date c = Calendar.getInstance().getTime();
+        SimpleDateFormat df = new SimpleDateFormat("dd-MMM-yyyy hh:mm");
+        return df.format(c);
+    }
+}

--- a/src/main/java/org/amahi/anywhere/util/Fragments.java
+++ b/src/main/java/org/amahi/anywhere/util/Fragments.java
@@ -56,6 +56,7 @@ public final class Fragments {
         public static final String FILE_OPTION = "file_option";
         public static final String IS_OFFLINE_FRAGMENT = "is_offline_fragment";
         public static final String DIALOG_TYPE = "dialog_type";
+        public static final String FILE_UNIQUE_KEY = "file_unique_key";
 
         private Arguments() {
         }

--- a/src/main/res/drawable/ic_info_outline.xml
+++ b/src/main/res/drawable/ic_info_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z"/>
+</vector>

--- a/src/main/res/layout/bottom_sheet_options.xml
+++ b/src/main/res/layout/bottom_sheet_options.xml
@@ -100,4 +100,26 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/file_info_layout"
+        style="@style/FileActionTheme"
+        android:layout_width="match_parent"
+        android:layout_height="56dp">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="32dp"
+            android:src="@drawable/ic_info_outline"
+            tools:ignore="contentDescription" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="File info"
+            android:textColor="@android:color/black"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/src/main/res/layout/file_info_dialog.xml
+++ b/src/main/res/layout/file_info_dialog.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Last opened"
+        android:textSize="14sp"
+        android:paddingStart="8dp"
+        android:paddingEnd="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/text_last_opened"
+        android:textStyle="bold"
+        android:textSize="14sp"
+        android:paddingStart="8dp"
+        android:paddingEnd="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="0dp"
+        android:textColor="@color/primary_text"/>
+
+
+</LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -188,6 +188,9 @@
     <string name="alert_delete_dialog">Delete file</string>
     <string name="alert_delete_confirm">Are you sure?</string>
 
+    <string name="title_file_info">File Info</string>
+    <string name="text_ok">OK</string>
+
     <string name="title_selected_server">Server</string>
 
     <string name="stop_the_audio" translatable="false">"Stop the audio"</string>


### PR DESCRIPTION
Fixes #551  

### Description:
I have taken the timestamps from the event listeners of the media library and storing them in SQLite format and displaying them accordingly on the interface of the recent files which stores and displays a list of files opened with their corresponding timestamps.

### Sample Demo:
![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/54114888/88496771-d1a10680-cfdb-11ea-9e40-4629e2b4e087.gif)

### Full Working Video Tested with many Components:
https://youtu.be/th1EesNS4_A







