### PR TITLE
Update libvlc version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
 
 
-    implementation 'org.videolan:libvlc:2.1.1'
+    implementation 'org.videolan:libvlc:2.1.16'
     implementation 'pub.devrel:easypermissions:3.0.0'
     testImplementation 'org.robolectric:robolectric:3.1.2'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Updated libvlc to the latest version available `2.1.16`. Earlier version `2.1.1`

Fixes: #214 