### PR TITLE
Update gitignore to include jks and keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ fabric.properties
 
 # Key
 signing.properties
-amahi-release-key.keystore
+*.keystore
+*.jks
 
 .DS*
 


### PR DESCRIPTION
Updated `.gitignore` to track both .jks and .keystore files and ignore them from getting added to the tree.