### PR TITLE
Avoiding white-spaces in username

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -74,32 +74,6 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
 
         setUpAuthentication();
 
-        avoidLeadingSpaceInUsername();
-    }
-
-    private void avoidLeadingSpaceInUsername() {
-        getUsernameEdit().addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-                if (!getUsername().isEmpty() && getUsername().trim().isEmpty())
-                    getUsernameEdit().setText("");
-                else if (!getUsername().isEmpty()) {
-                    while (getUsername().charAt(0) == ' ') {
-                        getUsernameEdit().setText(getUsername().substring(1));
-                    }
-                }
-            }
-        });
     }
 
     private void setUpInjections() {
@@ -220,7 +194,7 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
     }
 
     private void authenticate() {
-        amahiClient.authenticate(getUsername(), getPassword());
+        amahiClient.authenticate(getUsername().trim(), getPassword());
     }
 
     @Subscribe

--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -93,6 +93,11 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
             public void afterTextChanged(Editable editable) {
                 if (!getUsername().isEmpty() && getUsername().trim().isEmpty())
                     getUsernameEdit().setText("");
+                else if (!getUsername().isEmpty()) {
+                    while (getUsername().charAt(0) == ' ') {
+                        getUsernameEdit().setText(getUsername().substring(1));
+                    }
+                }
             }
         });
     }

--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -97,7 +97,7 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
                     getUsernameEdit().setText("");
                 else if (!getUsername().isEmpty()) {
                     while (getUsername().charAt(0) == ' ') {
-                        getUsernameEdit().setText(getUsernameEdit().getText().toString().substring(1));
+                        getUsernameEdit().setText(getUsername().substring(1));
                     }
                 }
             }

--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -79,17 +79,27 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
         avoidLeadingSpaceInUsername();
     }
 
-    private void avoidLeadingSpaceInUsername(){
+    private void avoidLeadingSpaceInUsername() {
         getUsernameEdit().addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
             @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
             @Override
             public void afterTextChanged(Editable editable) {
-                if (!getUsernameEdit().getText().toString().isEmpty())
-                    if (editable.toString().trim().isEmpty())
-                        getUsernameEdit().setText("");
+                if (!getUsername().isEmpty() && getUsername().trim().isEmpty())
+                    getUsernameEdit().setText("");
+                else if (!getUsername().isEmpty()) {
+                    while (getUsername().charAt(0) == ' ') {
+                        getUsernameEdit().setText(getUsernameEdit().getText().toString().substring(1));
+                    }
+                }
             }
         });
     }
@@ -212,7 +222,7 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
     }
 
     private void authenticate() {
-        amahiClient.authenticate(getUsername().trim(), getPassword());
+        amahiClient.authenticate(getUsername(), getPassword());
     }
 
     @Subscribe

--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -24,11 +24,6 @@ import android.accounts.AccountManager;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
-
-import com.google.android.material.textfield.TextInputLayout;
-
-import androidx.appcompat.app.AppCompatDelegate;
-
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.method.LinkMovementMethod;
@@ -37,7 +32,10 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.appcompat.app.AppCompatDelegate;
+
 import com.dd.processbutton.iml.ActionProcessButton;
+import com.google.android.material.textfield.TextInputLayout;
 import com.squareup.otto.Subscribe;
 
 import org.amahi.anywhere.AmahiApplication;
@@ -79,17 +77,22 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
         avoidLeadingSpaceInUsername();
     }
 
-    private void avoidLeadingSpaceInUsername(){
+    private void avoidLeadingSpaceInUsername() {
         getUsernameEdit().addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
             @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
             @Override
             public void afterTextChanged(Editable editable) {
-                if (!getUsernameEdit().getText().toString().isEmpty())
-                    if (editable.toString().trim().isEmpty())
-                        getUsernameEdit().setText("");
+                if (!getUsername().isEmpty() && getUsername().trim().isEmpty())
+                    getUsernameEdit().setText("");
             }
         });
     }
@@ -212,7 +215,7 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
     }
 
     private void authenticate() {
-        amahiClient.authenticate(getUsername().trim(), getPassword());
+        amahiClient.authenticate(getUsername(), getPassword());
     }
 
     @Subscribe

--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -75,6 +75,23 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
         setUpInjections();
 
         setUpAuthentication();
+
+        avoidLeadingSpaceInUsername();
+    }
+
+    private void avoidLeadingSpaceInUsername(){
+        getUsernameEdit().addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+            @Override
+            public void afterTextChanged(Editable editable) {
+                if (!getUsernameEdit().getText().toString().isEmpty())
+                    if (editable.toString().trim().isEmpty())
+                        getUsernameEdit().setText("");
+            }
+        });
     }
 
     private void setUpInjections() {
@@ -195,7 +212,7 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
     }
 
     private void authenticate() {
-        amahiClient.authenticate(getUsername(), getPassword());
+        amahiClient.authenticate(getUsername().trim(), getPassword());
     }
 
     @Subscribe


### PR DESCRIPTION
1. White-space will not be accepted as first character in username.

**Before:**
![before](https://user-images.githubusercontent.com/58542044/89114730-65247c80-d49f-11ea-8e5e-e223ad6f202c.gif)


**After:**
![after](https://user-images.githubusercontent.com/58542044/89114784-06133780-d4a0-11ea-82f3-3cf512715437.gif)


2. Leading and trailing white-spaces in username will be trimmed before going for authentication. Thus server need not check for the same.

Hope that it is useful.