### PR TITLE
Disable ACRA During CI Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This is something to keep **private** and you obtain it by sending a message to 
   ```
   ```
   mailto.email = myemail@mydomain.com
+  mail.send = true
   ```
 
 Enter your personal email in place of `myemail@mydomain.com`

--- a/acra.properties.sample
+++ b/acra.properties.sample
@@ -1,4 +1,7 @@
 # Set ACRA mailing information in acra.properties.
 # This is something to keep private and can be created by following steps in README.md
+# "mail.send = false" won't send a crash report
+# "mail.send = true" will enable sending crash reports
 
 mailto.email = myemail@mydomain.com
+mail.send = true

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ android {
         buildConfigField "String", "API_CLIENT_SECRET", formatStringField(apiProperties["client.secret"])
         buildConfigField "String", "CHROMECAST_APP_ID", formatStringField(apiProperties["chromecast.app.id"])
         buildConfigField "String", "ACRA_EMAIL", formatStringField(acraProperties["mailto.email"])
+        buildConfigField "String", "ACRA_SEND", formatStringField(acraProperties["mail.send"])
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fakeAcra.properties
+++ b/fakeAcra.properties
@@ -3,3 +3,4 @@
 # Purpose: This file is required for Tests and Travis checks to pass
 
 mailto.email = myemail@mydomain.com
+mail.send = false

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -178,27 +178,29 @@ public class AmahiApplication extends Application {
         super.attachBaseContext(base);
         if (isDebugging()) {
 
-            CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
-                .setBuildConfigClass(BuildConfig.class)
-                .setReportFormat(StringFormat.JSON)
-                .setAlsoReportToAndroidFramework(true)
-                .setReportContent(ReportField.APP_VERSION_CODE)
-                .setReportContent(ReportField.APP_VERSION_NAME)
-                .setReportContent(ReportField.ANDROID_VERSION)
-                .setReportContent(ReportField.PHONE_MODEL)
-                .setReportContent(ReportField.CUSTOM_DATA)
-                .setReportContent(ReportField.STACK_TRACE)
-                .setReportContent(ReportField.LOGCAT);
+            if(Api.toSendMail()) {
+                CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
+                    .setBuildConfigClass(BuildConfig.class)
+                    .setReportFormat(StringFormat.JSON)
+                    .setAlsoReportToAndroidFramework(true)
+                    .setReportContent(ReportField.APP_VERSION_CODE)
+                    .setReportContent(ReportField.APP_VERSION_NAME)
+                    .setReportContent(ReportField.ANDROID_VERSION)
+                    .setReportContent(ReportField.PHONE_MODEL)
+                    .setReportContent(ReportField.CUSTOM_DATA)
+                    .setReportContent(ReportField.STACK_TRACE)
+                    .setReportContent(ReportField.LOGCAT);
 
-            builder.getPluginConfigurationBuilder(MailSenderConfigurationBuilder.class)
-                .setMailTo(Api.getAcraEmail())
-                .setEnabled(true);
+                builder.getPluginConfigurationBuilder(MailSenderConfigurationBuilder.class)
+                    .setMailTo(Api.getAcraEmail())
+                    .setEnabled(true);
 
-            builder.getPluginConfigurationBuilder(ToastConfigurationBuilder.class)
-                .setResText(R.string.acra_report_toast)
-                .setEnabled(true);
+                builder.getPluginConfigurationBuilder(ToastConfigurationBuilder.class)
+                    .setResText(R.string.acra_report_toast)
+                    .setEnabled(true);
 
-            ACRA.init(this, builder);
+                ACRA.init(this, builder);
+            }
         }
     }
 }

--- a/src/main/java/org/amahi/anywhere/server/Api.java
+++ b/src/main/java/org/amahi/anywhere/server/Api.java
@@ -47,4 +47,8 @@ public final class Api {
     public static String getAcraEmail() {
         return BuildConfig.ACRA_EMAIL;
     }
+
+    public static boolean toSendMail() {
+        return Boolean.parseBoolean(BuildConfig.ACRA_SEND);
+    }
 }


### PR DESCRIPTION
ACRA usually causes the travis builds to fail since it would block the UI of the virtual device by opening the email application in case of a crash. With this PR, I'm adding a flag to enable/disable ACRA by making a small change in the properties file.