### PR TITLE
Remove Fabric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        maven { url 'https://maven.fabric.io/public' }
         google()
         jcenter()
     }
@@ -8,12 +7,10 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'io.fabric.tools:gradle:1.28.1'
     }
 }
 
 apply plugin: "com.android.application"
-apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 28
@@ -126,7 +123,6 @@ dependencies {
         google()
         mavenCentral()
         mavenLocal()
-        maven { url 'https://maven.fabric.io/public' }
         maven { url 'http://dl.bintray.com/megabitdragon/maven' }
         maven { url 'https://jitpack.io' }
         jcenter()
@@ -144,9 +140,6 @@ dependencies {
     implementation "androidx.media:media:${SUPPORT_LIBRARY_VERSION}"
     implementation "androidx.cardview:cardview:${SUPPORT_LIBRARY_VERSION}"
     implementation 'com.google.android.gms:play-services-cast-framework:11.6.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.6.6@aar') {
-        transitive = true
-    }
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
     implementation 'com.github.dmytrodanylyk.android-process-button:library:1.0.4'
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -31,8 +31,6 @@ import android.preference.PreferenceManager;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatDelegate;
 
-import com.crashlytics.android.Crashlytics;
-
 import org.acra.ACRA;
 import org.acra.ReportField;
 import org.acra.config.CoreConfigurationBuilder;
@@ -44,7 +42,6 @@ import org.amahi.anywhere.job.PhotosContentJob;
 import org.amahi.anywhere.server.Api;
 
 import dagger.ObjectGraph;
-import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
 
 /**
@@ -76,7 +73,6 @@ public class AmahiApplication extends Application {
 
         instance = this;
         setUpLogging();
-        setUpReporting();
         setUpDetecting();
 
         setUpInjections();
@@ -118,12 +114,6 @@ public class AmahiApplication extends Application {
 
     private boolean isDebugging() {
         return BuildConfig.DEBUG;
-    }
-
-    private void setUpReporting() {
-        if (!isDebugging()) {
-            Fabric.with(this, new Crashlytics());
-        }
     }
 
     private void setUpDetecting() {
@@ -178,7 +168,7 @@ public class AmahiApplication extends Application {
         super.attachBaseContext(base);
         if (isDebugging()) {
 
-            if(Api.toSendMail()) {
+            if (Api.toSendMail()) {
                 CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
                     .setBuildConfigClass(BuildConfig.class)
                     .setReportFormat(StringFormat.JSON)

--- a/src/main/java/org/amahi/anywhere/util/FileManager.java
+++ b/src/main/java/org/amahi/anywhere/util/FileManager.java
@@ -2,6 +2,8 @@ package org.amahi.anywhere.util;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.AsyncTask;
+
 import androidx.core.content.FileProvider;
 
 import org.amahi.anywhere.bus.BusProvider;
@@ -10,13 +12,10 @@ import org.amahi.anywhere.bus.FileMovedEvent;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import io.fabric.sdk.android.services.concurrency.AsyncTask;
 
 public class FileManager {
 
@@ -74,8 +73,6 @@ public class FileManager {
                 in.close();
                 out.close();
 
-            } catch (FileNotFoundException e) {
-                e.printStackTrace();
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Removed dependency on Fabric which is a deprecated library for Crashlytics.
This is a step towards solving Issue #597 and #540 since we can't integrate Firebase while we have Fabric in the app.

Also switched the dependency of FileManager on Fabric and switched to the Android's own library for the asynchronous task. 
Following tasks work fine
- [x] File upload
- [x] File download
- [x] Marking a file as offline
- [x] Accessing offline file