### PR TITLE
File Options in Offline Files

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/FileOptionsDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/FileOptionsDialogFragment.java
@@ -1,13 +1,15 @@
 package org.amahi.anywhere.fragment;
 
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
-import androidx.appcompat.widget.SwitchCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SwitchCompat;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.amahi.anywhere.R;
 import org.amahi.anywhere.bus.BusProvider;

--- a/src/main/java/org/amahi/anywhere/fragment/FileOptionsDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/FileOptionsDialogFragment.java
@@ -70,6 +70,7 @@ public class FileOptionsDialogFragment extends BottomSheetDialogFragment {
             }
         } else {
             offlineLayout.setVisibility(View.GONE);
+            downloadLayout.setVisibility(View.GONE);
         }
     }
 

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -1018,7 +1018,7 @@ public class ServerFilesFragment extends Fragment implements
             Fragments.Builder.buildFileOptionsDialogFragment(getContext(), getCheckedFile())
                 .show(getChildFragmentManager(), "file_options_dialog");
         } else {
-            Fragments.Builder.buildOfflineFileOptionsDialogFragment()
+            Fragments.Builder.buildOfflineFileOptionsDialogFragment(getCheckedFile())
                 .show(getChildFragmentManager(), "file_options_dialog");
         }
     }

--- a/src/main/java/org/amahi/anywhere/server/model/ServerFile.java
+++ b/src/main/java/org/amahi/anywhere/server/model/ServerFile.java
@@ -19,15 +19,14 @@
 
 package org.amahi.anywhere.server.model;
 
-import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+
 import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
-import org.amahi.anywhere.R;
 import org.amahi.anywhere.util.Constants;
 
 import java.security.MessageDigest;

--- a/src/main/java/org/amahi/anywhere/util/Fragments.java
+++ b/src/main/java/org/amahi/anywhere/util/Fragments.java
@@ -22,11 +22,11 @@ package org.amahi.anywhere.util;
 import android.content.Context;
 import android.os.Bundle;
 
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
-
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
-import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.amahi.anywhere.fragment.AudioListFragment;
 import org.amahi.anywhere.fragment.FileOptionsDialogFragment;
@@ -182,11 +182,12 @@ public final class Fragments {
             return fragment;
         }
 
-        public static BottomSheetDialogFragment buildOfflineFileOptionsDialogFragment() {
+        public static BottomSheetDialogFragment buildOfflineFileOptionsDialogFragment(ServerFile file) {
             BottomSheetDialogFragment fragment = new FileOptionsDialogFragment();
 
             Bundle bundle = new Bundle();
             bundle.putBoolean(Arguments.IS_OFFLINE_FRAGMENT, true);
+            bundle.putParcelable(Arguments.SERVER_FILE, file);
             fragment.setArguments(bundle);
             return fragment;
         }


### PR DESCRIPTION
Fixes #599 

1. File object wasn't passed to the Offline Files Activity which is solved in this PR. 
2. This PR also removes the "Save to Device" option from Offline Files since it is already present on the device and this option just checks for the existence of file but doesn't actually download.

Earlier Screenshot:
<img src="https://user-images.githubusercontent.com/31701616/89720500-6fd79800-d9f0-11ea-9287-d1f1f75ae0dc.png" width="250">

New Screenshot:
<img src="https://user-images.githubusercontent.com/31701616/89720504-749c4c00-d9f0-11ea-881b-855d7af4018c.png" width="250">
