### PR TITLE
Remove Timber Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,10 +87,12 @@ android {
     buildTypes {
         betaRelease {
             signingConfig signingConfigs.debug
+            debuggable false
         }
 
         release {
             signingConfig signingConfigs.release
+            debuggable false
         }
     }
 
@@ -149,7 +151,6 @@ dependencies {
     }
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
     implementation 'com.github.dmytrodanylyk.android-process-button:library:1.0.4'
-    implementation 'com.jakewharton.timber:timber:4.7.1'
 
 //    Otto and Retrofit
     implementation 'com.squareup:otto:1.3.8'

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -45,7 +45,6 @@ import org.amahi.anywhere.server.Api;
 
 import dagger.ObjectGraph;
 import io.fabric.sdk.android.Fabric;
-import timber.log.Timber;
 
 /**
  * Application declaration. Basically sets things up at the startup time,
@@ -75,7 +74,6 @@ public class AmahiApplication extends Application {
         super.onCreate();
 
         instance = this;
-        setUpLogging();
         setUpReporting();
         setUpDetecting();
 
@@ -87,12 +85,6 @@ public class AmahiApplication extends Application {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             setUpJobs();
-        }
-    }
-
-    private void setUpLogging() {
-        if (isDebugging()) {
-            Timber.plant(new Timber.DebugTree());
         }
     }
 

--- a/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/ServerFilesActivity.java
@@ -33,6 +33,7 @@ import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -100,7 +101,6 @@ import javax.inject.Inject;
 
 import pub.devrel.easypermissions.AppSettingsDialog;
 import pub.devrel.easypermissions.EasyPermissions;
-import timber.log.Timber;
 
 /**
  * Files activity. Shows files navigation and operates basic file actions,
@@ -112,6 +112,8 @@ public class ServerFilesActivity extends AppCompatActivity implements
     ServiceConnection,
     CastStateListener,
     AlertDialogFragment.DuplicateFileDialogCallback {
+
+    public static final String TAG = ServerFilesActivity.class.getSimpleName();
 
     private static final int FILE_UPLOAD_PERMISSION = 102;
     private static final int CAMERA_PERMISSION = 103;
@@ -438,7 +440,7 @@ public class ServerFilesActivity extends AppCompatActivity implements
                 cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
                 startActivityForResult(cameraIntent, REQUEST_CAMERA_IMAGE);
             } catch (IOException ex) {
-                Timber.d(ex);
+                Log.d(TAG, ex.getMessage());
             }
         }
     }

--- a/src/main/java/org/amahi/anywhere/fragment/ServerAppsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerAppsFragment.java
@@ -47,7 +47,6 @@ import org.amahi.anywhere.bus.ServerConnectionChangedEvent;
 import org.amahi.anywhere.server.client.ServerClient;
 import org.amahi.anywhere.server.model.ServerApp;
 import org.amahi.anywhere.util.ViewDirector;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -234,7 +233,7 @@ public class ServerAppsFragment extends Fragment {
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
         tearDownAppsState(outState);

--- a/src/main/java/org/amahi/anywhere/server/ApiConnectionDetector.java
+++ b/src/main/java/org/amahi/anywhere/server/ApiConnectionDetector.java
@@ -19,10 +19,9 @@
 
 package org.amahi.anywhere.server;
 
-import android.content.res.Resources;
 import android.net.Uri;
+import android.util.Log;
 
-import org.amahi.anywhere.R;
 import org.amahi.anywhere.server.model.ServerRoute;
 import org.amahi.anywhere.util.Constants;
 
@@ -33,13 +32,15 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import timber.log.Timber;
 
 /**
  * API connection guesser. Tries to connect to the server address to determine if it is available
  * and returns it if succeed or another one otherwise.
  */
 public class ApiConnectionDetector {
+
+    public static final String TAG = ApiConnectionDetector.class.getSimpleName();
+
     private OkHttpClient httpClient;
 
     public ApiConnectionDetector() {
@@ -54,7 +55,7 @@ public class ApiConnectionDetector {
     }
 
     public String detect(ServerRoute serverRoute) {
-        Timber.tag(Constants.connection);
+        Log.d(TAG, Constants.connection);
 
         try {
             Request httpRequest = new Request.Builder()
@@ -67,11 +68,11 @@ public class ApiConnectionDetector {
 
             httpResponse.body().close();
 
-            Timber.d("Using local address.");
+            Log.d(TAG, "Using local address.");
 
             return serverRoute.getLocalAddress();
         } catch (IOException e) {
-            Timber.d("Using remote address.");
+            Log.d(TAG, "Using remote address.");
 
             return serverRoute.getRemoteAddress();
         }


### PR DESCRIPTION
`Timber` is an alternate logging library proposed in front of the default `Android.Log` library and just provides a shorthand of using `Timber.d(msg)` in place of `Log.d(TAG, msg)`. 
However, it's rarely used in the codebase and we can remove its dependency to reduce the final apk size.