### PR TITLE
Added Amahi themed swipe refresh

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -757,11 +757,7 @@ public class ServerFilesFragment extends Fragment implements
         SwipeRefreshLayout refreshLayout = getRefreshLayout();
 
         refreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent);
-        refreshLayout.setColorSchemeResources(
-            /*android.R.color.holo_blue_light,
-            android.R.color.holo_orange_light,
-            android.R.color.holo_green_light,
-            android.R.color.holo_red_light);*/
+        refreshLayout.setColorSchemeResources(       
             android.R.color.white);
 
         refreshLayout.setOnRefreshListener(this);

--- a/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerFilesFragment.java
@@ -756,11 +756,13 @@ public class ServerFilesFragment extends Fragment implements
     private void setUpFilesContentRefreshing() {
         SwipeRefreshLayout refreshLayout = getRefreshLayout();
 
+        refreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent);
         refreshLayout.setColorSchemeResources(
-            android.R.color.holo_blue_light,
+            /*android.R.color.holo_blue_light,
             android.R.color.holo_orange_light,
             android.R.color.holo_green_light,
-            android.R.color.holo_red_light);
+            android.R.color.holo_red_light);*/
+            android.R.color.white);
 
         refreshLayout.setOnRefreshListener(this);
     }

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -95,7 +95,7 @@ public class ServerSharesFragment extends Fragment implements
 
     private void setSwipeToRefresh() {
         mSwipeRefreshLayout.setOnRefreshListener(this);
-        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent)
+        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(Rcolor.accent);
         mSwipeRefreshLayout.setColorSchemeResources(
             android.R.color.white);
     }

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -95,7 +95,7 @@ public class ServerSharesFragment extends Fragment implements
 
     private void setSwipeToRefresh() {
         mSwipeRefreshLayout.setOnRefreshListener(this);
-        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent);
+        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent)
         mSwipeRefreshLayout.setColorSchemeResources(
             android.R.color.white);
     }

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -95,7 +95,7 @@ public class ServerSharesFragment extends Fragment implements
 
     private void setSwipeToRefresh() {
         mSwipeRefreshLayout.setOnRefreshListener(this);
-        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(Rcolor.accent);
+        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent);
         mSwipeRefreshLayout.setColorSchemeResources(
             android.R.color.white);
     }

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -95,6 +95,9 @@ public class ServerSharesFragment extends Fragment implements
 
     private void setSwipeToRefresh() {
         mSwipeRefreshLayout.setOnRefreshListener(this);
+        mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.accent);
+        mSwipeRefreshLayout.setColorSchemeResources(
+            android.R.color.white);
     }
 
     @Override


### PR DESCRIPTION
Fixes: #623
### Description:
Added Amahi Android App themed Swipe Refresh indicator. The refresh indicator implemented changes its background tint with respect to light or dark mode as demonstrated below.
This feature is inspired from GitHub Android App.

### Screenshot Before:
![Screenshot_2020-08-17-11-10-40-84_8f7f52555d974a92fa29728873f61978](https://user-images.githubusercontent.com/54114888/90363332-289c7780-e080-11ea-9801-5ac0c2ca759c.jpg)

### Dark Theme Demo:
![ezgif com-video-to-gif (33)](https://user-images.githubusercontent.com/54114888/90363682-b7a98f80-e080-11ea-9304-7618b87c2116.gif)

### Light Theme Demo:
![ezgif com-video-to-gif (34)](https://user-images.githubusercontent.com/54114888/90363771-e1fb4d00-e080-11ea-9ff6-2f769db4992a.gif)
