### PR TITLE
Change recyclerview reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,8 +177,9 @@ dependencies {
     implementation "com.google.android.exoplayer:exoplayer-core:${EXOPLAYER_VERSION}"
     implementation "com.google.android.exoplayer:exoplayer-ui:${EXOPLAYER_VERSION}"
 
-    implementation 'android.arch.persistence.room:runtime:' + rootProject.archRoomVersion
-    annotationProcessor 'android.arch.persistence.room:compiler:' + rootProject.archRoomVersion
+    def room_version = "2.2.5"
+    implementation "androidx.room:room-runtime:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
 
     def acraVersion = '5.7.0'
     implementation "ch.acra:acra-mail:$acraVersion"

--- a/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java
@@ -188,8 +188,8 @@ public class ServerSharesFragment extends Fragment implements
     @Subscribe
     public void onServerConnectionChanged(ServerConnectionChangedEvent event) {
         ViewDirector.of(getActivity(), R.id.animator).show(android.R.id.progress);
-        if (mRecyclerView != null)
-            mRecyclerView.removeAllViews();
+        if (mFastScrollView!=null)
+            mFastScrollView.getRecyclerView().removeAllViews();
         setUpSharesContent();
     }
 


### PR DESCRIPTION
Fix issues which caused the travis build to crash after merging #622 and #629 and caused conflicts in ServerSharesFragment.java

#622 introduced this new variable and removed `mRecyclerView`
https://github.com/chirag-jn/android/blob/6521e56bdb0cee0acffd8583d89ddeb0abf98423/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java#L63

But in #629, we are still using `mRecyclerView`
https://github.com/chirag-jn/android/blob/3853358758613d011535c0ed687dcc6574ea2bd9/src/main/java/org/amahi/anywhere/fragment/ServerSharesFragment.java#L191-L192

This PR replaces `mRecyclerView` with `mFastScrollView`