### PR TITLE
Dismiss Dialogs Before Running AuthActivity Test

### DIFF
--- a/src/androidTest/java/org/amahi/anywhere/activity/AuthenticationActivityTest.java
+++ b/src/androidTest/java/org/amahi/anywhere/activity/AuthenticationActivityTest.java
@@ -1,5 +1,7 @@
 package org.amahi.anywhere.activity;
 
+import android.content.Intent;
+
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
@@ -24,6 +26,8 @@ public class AuthenticationActivityTest {
 
     @Test
     public void testIsErrorMessageDisplayed_UsernameOrPasswordIsEmpty() {
+        authenticationActivityTestRule.getActivity().sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+
         onView(withId(R.id.username_layout)).check(matches(isDisplayed()));
         onView(withId(R.id.password_layout)).check(matches(isDisplayed()));
 


### PR DESCRIPTION
Due to the nature of the virtual device, Travis creates a new device every time a new Travis build runs. However, we usually see that the first task (building the app) runs successfully, but the second task (testing the app) fails. 
It usually happens because the app lost its focus after an alert box is displayed. 
This PR instructs the virtual device to dismiss all alert boxes before running the tests.