### PR TITLE
Remove ACRA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ signing.properties
 *.jks
 
 .DS*
-
-# Acra
-acra.properties

--- a/README.md
+++ b/README.md
@@ -31,25 +31,13 @@ You will need JDK 1.8+ installed to work with it. Gradle, Android SDK, and proje
 
 This is something to keep **private** and you obtain it by sending a message to <support@amahi.org>.
 
-2. Set ACRA information
-
-  ```
-  $ vim acra.properties
-  ```
-  ```
-  mailto.email = myemail@mydomain.com
-  mail.send = true
-  ```
-
-Enter your personal email in place of `myemail@mydomain.com`
-
-3. Build the application using a command line or using GUI.
+2. Build the application using a command line or using GUI.
 
   ```
   $ ./gradlew clean assembleDebug
   ```
 
-4. Once you have built the application, you will be needing credentials to use the application. Go to Amahi website and create your account, once the account is activated, you will see the description on how to set up the Amahi server. However, this is not strictly needed, as we have a set up of a demo server called "Welcome to Amahi" which you should see even without your own server installed.
+3. Once you have built the application, you will be needing credentials to use the application. Go to Amahi website and create your account, once the account is activated, you will see the description on how to set up the Amahi server. However, this is not strictly needed, as we have a set up of a demo server called "Welcome to Amahi" which you should see even without your own server installed.
 
 ## Code Style Convention
 

--- a/acra.properties.sample
+++ b/acra.properties.sample
@@ -1,7 +1,0 @@
-# Set ACRA mailing information in acra.properties.
-# This is something to keep private and can be created by following steps in README.md
-# "mail.send = false" won't send a crash report
-# "mail.send = true" will enable sending crash reports
-
-mailto.email = myemail@mydomain.com
-mail.send = true

--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,10 @@ android {
         targetSdkVersion 29
 
         def apiFile = file("api.properties")
-        def acraFile = file("acra.properties")
         def apiProperties = new Properties()
-        def acraProperties = new Properties()
 
-        // NOTE-cpg: this fakeApi and fakeAcra is here for the tests to pass
+        // NOTE-cpg: this fakeApi is here for the tests to pass
         def fakeApiFile = file("fakeApi.properties")
-        def fakeAcraFile = file("fakeAcra.properties")
 
         if (apiFile.exists()) {
             apiProperties.load(apiFile.newInputStream())
@@ -64,19 +61,11 @@ android {
             apiProperties.load(fakeApiFile.newInputStream())
         }
 
-        if (acraFile.exists()) {
-            acraProperties.load(acraFile.newInputStream())
-        } else {
-            acraProperties.load(fakeAcraFile.newInputStream())
-        }
-
         buildConfigField "String", "API_URL_AMAHI", formatStringField(apiProperties["url.amahi"])
         buildConfigField "String", "API_URL_PROXY", formatStringField(apiProperties["url.proxy"])
         buildConfigField "String", "API_CLIENT_ID", formatStringField(apiProperties["client.id"])
         buildConfigField "String", "API_CLIENT_SECRET", formatStringField(apiProperties["client.secret"])
         buildConfigField "String", "CHROMECAST_APP_ID", formatStringField(apiProperties["chromecast.app.id"])
-        buildConfigField "String", "ACRA_EMAIL", formatStringField(acraProperties["mailto.email"])
-        buildConfigField "String", "ACRA_SEND", formatStringField(acraProperties["mail.send"])
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -180,12 +169,6 @@ dependencies {
     def room_version = "2.2.5"
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
-
-    def acraVersion = '5.7.0'
-    implementation "ch.acra:acra-mail:$acraVersion"
-    implementation "ch.acra:acra-dialog:$acraVersion"
-    implementation "ch.acra:acra-notification:$acraVersion"
-    implementation "ch.acra:acra-toast:$acraVersion"
 
     // Uncomment the dependencies below to enable Chuck Interceptor for logging
 /*

--- a/fakeAcra.properties
+++ b/fakeAcra.properties
@@ -1,6 +1,0 @@
-# Set ACRA mailing information in acra.properties.
-# This is something to keep private and can be created by following steps in README.md
-# Purpose: This file is required for Tests and Travis checks to pass
-
-mailto.email = myemail@mydomain.com
-mail.send = false

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.READ_LOGS"/>
 
     <permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
 

--- a/src/main/java/org/amahi/anywhere/AmahiApplication.java
+++ b/src/main/java/org/amahi/anywhere/AmahiApplication.java
@@ -31,15 +31,8 @@ import android.preference.PreferenceManager;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatDelegate;
 
-import org.acra.ACRA;
-import org.acra.ReportField;
-import org.acra.config.CoreConfigurationBuilder;
-import org.acra.config.MailSenderConfigurationBuilder;
-import org.acra.config.ToastConfigurationBuilder;
-import org.acra.data.StringFormat;
 import org.amahi.anywhere.job.NetConnectivityJob;
 import org.amahi.anywhere.job.PhotosContentJob;
-import org.amahi.anywhere.server.Api;
 
 import dagger.ObjectGraph;
 
@@ -155,36 +148,5 @@ public class AmahiApplication extends Application {
         NotificationManager notificationManager = getSystemService(NotificationManager.class);
         notificationManager.createNotificationChannel(uploadChannel);
         notificationManager.createNotificationChannel(downloadChannel);
-    }
-
-    @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        if (isDebugging()) {
-
-            if (Api.toSendMail()) {
-                CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this)
-                    .setBuildConfigClass(BuildConfig.class)
-                    .setReportFormat(StringFormat.JSON)
-                    .setAlsoReportToAndroidFramework(true)
-                    .setReportContent(ReportField.APP_VERSION_CODE)
-                    .setReportContent(ReportField.APP_VERSION_NAME)
-                    .setReportContent(ReportField.ANDROID_VERSION)
-                    .setReportContent(ReportField.PHONE_MODEL)
-                    .setReportContent(ReportField.CUSTOM_DATA)
-                    .setReportContent(ReportField.STACK_TRACE)
-                    .setReportContent(ReportField.LOGCAT);
-
-                builder.getPluginConfigurationBuilder(MailSenderConfigurationBuilder.class)
-                    .setMailTo(Api.getAcraEmail())
-                    .setEnabled(true);
-
-                builder.getPluginConfigurationBuilder(ToastConfigurationBuilder.class)
-                    .setResText(R.string.acra_report_toast)
-                    .setEnabled(true);
-
-                ACRA.init(this, builder);
-            }
-        }
     }
 }

--- a/src/main/java/org/amahi/anywhere/server/Api.java
+++ b/src/main/java/org/amahi/anywhere/server/Api.java
@@ -43,12 +43,4 @@ public final class Api {
     public static String getClientSecret() {
         return BuildConfig.API_CLIENT_SECRET;
     }
-
-    public static String getAcraEmail() {
-        return BuildConfig.ACRA_EMAIL;
-    }
-
-    public static boolean toSendMail() {
-        return Boolean.parseBoolean(BuildConfig.ACRA_SEND);
-    }
 }


### PR DESCRIPTION
Since we have resolved the primary objective of adding ACRA (i.e. solving background crashes #630), there's no real benefit provided by ACRA since we aren't planning to use ACRA in the release version. So I guess it's better to remove the library to reduce APK size.

This PR reverts the changes made by #593 and #565 