### PR TITLE
Added Styled Logout Toast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
 
+    implementation 'com.muddzdev:styleabletoast:2.2.3'
     implementation "com.vorlonsoft:androidrate:1.2.1"
 
     implementation 'org.videolan:libvlc:2.1.16'

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -254,7 +254,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
 
     @Override
     public void run(AccountManagerFuture<Boolean> accountManagerFuture) {
-        StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show()
+        StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show();
         tearDownActivity();
     }
 

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -256,7 +256,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
     @Override
     public void run(AccountManagerFuture<Boolean> accountManagerFuture) {
         //Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
-        StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show();
+        StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show()
         tearDownActivity();
     }
 

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -255,7 +255,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
 
     @Override
     public void run(AccountManagerFuture<Boolean> accountManagerFuture) {
-        //Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
         StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show()
         tearDownActivity();
     }

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -238,8 +238,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
             Account account = getAccounts().get(0);
 
             getAccountManager().removeAccount(account, this, null);
-        } else {
-            //Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
+        } else {            
             StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show();
             tearDownActivity();
         }

--- a/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/SettingsFragment.java
@@ -34,6 +34,7 @@ import androidx.preference.PreferenceManager;
 import androidx.annotation.Nullable;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.muddzdev.styleabletoast.StyleableToast;
 
 import androidx.appcompat.app.AppCompatDelegate;
 
@@ -238,7 +239,8 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
 
             getAccountManager().removeAccount(account, this, null);
         } else {
-            Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
+            //Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
+            StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show();
             tearDownActivity();
         }
     }
@@ -253,7 +255,8 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
 
     @Override
     public void run(AccountManagerFuture<Boolean> accountManagerFuture) {
-        Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
+        //Toast.makeText(getActivity(), R.string.message_logout, Toast.LENGTH_SHORT).show();
+        StyleableToast.makeText(getActivity(), "Logged out successfully", Toast.LENGTH_LONG, R.style.loggoutToast).show();
         tearDownActivity();
     }
 

--- a/src/main/res/drawable/ic_loggout_toast.xml
+++ b/src/main/res/drawable/ic_loggout_toast.xml
@@ -1,0 +1,9 @@
+<vector
+    android:height="36dp"
+    android:tint="#FFFFFF"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="36dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,1.01L8,1c-1.1,0 -2,0.9 -2,2v3h2V5h10v14H8v-1H6v3c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V3c0,-1.1 -0.9,-1.99 -2,-1.99zM10,15h2V8H5v2h3.59L3,15.59 4.41,17 10,11.41z"/>
+</vector>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -148,6 +148,18 @@
         <item name="android:textColor">@color/primary_text</item>
     </style>
 
+    <style name="loggoutToast">
+        <item name="stTextBold">true</item>
+        <item name="stTextColor">#ffffff</item>
+        <item name="stTextSize">15sp</item>
+        <item name="stColorBackground">@color/accent</item>
+        <item name="stSolidBackground">true</item>
+        <item name="stStrokeWidth">0sp</item>
+        <item name="stStrokeColor">@color/accent</item>
+        <item name="stIconStart">@drawable/ic_loggout_toast</item>
+        <item name="stLength">LONG</item> LONG or SHORT
+        <item name="stRadius">30sp</item>
+    </style>
 
 
 </resources>


### PR DESCRIPTION
Fixes: #639

### Description:
Added Amahi Android App themed Styled Logout Toast. This is invoked when a user signs out of the app manually.

### Screenshot Before:
![Screenshot_2020-08-23-21-31-20-38_8f7f52555d974a92fa29728873f61978](https://user-images.githubusercontent.com/54114888/91019209-42086b00-e60e-11ea-91e0-b3b29f736825.jpg)

### Dark Theme Demo:
![ezgif com-video-to-gif (36)](https://user-images.githubusercontent.com/54114888/91019435-9ad80380-e60e-11ea-8ec4-cce71d91e1b1.gif)

### Light Theme Demo:
![ezgif com-video-to-gif (37)](https://user-images.githubusercontent.com/54114888/91019515-be02b300-e60e-11ea-8c61-475937238ecd.gif)