### PR TITLE
Added red status bar and stroke for errors

### DIFF
--- a/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
+++ b/src/main/java/org/amahi/anywhere/activity/AuthenticationActivity.java
@@ -23,6 +23,8 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -90,6 +92,7 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
     }
 
     private EditText getUsernameEdit() {
+
         TextInputLayout username_layout = findViewById(R.id.username_layout);
         return username_layout.getEditText();
     }
@@ -157,14 +160,45 @@ public class AuthenticationActivity extends AccountAuthenticatorAppCompatActivit
         if (getUsername().trim().isEmpty() || getPassword().trim().isEmpty()) {
             ViewDirector.of(this, R.id.animator_message).show(R.id.text_message_authentication_empty);
 
-            if (getUsername().trim().isEmpty())
-                getUsernameEdit().requestFocus();
 
-            if (getPassword().trim().isEmpty())
+            if (getUsername().trim().isEmpty()){
+
+                getWindow().setStatusBarColor(getResources().getColor(R.color.error_red));
+
+                TextInputLayout username_layout = findViewById(R.id.username_layout);
+                TextInputLayout password_layout = findViewById(R.id.password_layout);
+
+                username_layout.setBoxStrokeColor(getResources().getColor(R.color.error_red));
+                password_layout.setBoxStrokeColor(getResources().getColor(R.color.error_red));
+
+                getUsernameEdit().requestFocus();
+            }
+
+            if (getPassword().trim().isEmpty()){
+
+                getWindow().setStatusBarColor(getResources().getColor(R.color.error_red));
+
+                TextInputLayout username_layout = findViewById(R.id.username_layout);
+                TextInputLayout password_layout = findViewById(R.id.password_layout);
+
+                username_layout.setBoxStrokeColor(getResources().getColor(R.color.error_red));
+                password_layout.setBoxStrokeColor(getResources().getColor(R.color.error_red));
+
                 getPasswordEdit().requestFocus();
+            }
 
-            if (getUsername().trim().isEmpty() && getPassword().trim().isEmpty())
+            if (getUsername().trim().isEmpty() && getPassword().trim().isEmpty()){
+
+                getWindow().setStatusBarColor(getResources().getColor(R.color.error_red));
+
+                TextInputLayout username_layout = findViewById(R.id.username_layout);
+                TextInputLayout password_layout = findViewById(R.id.password_layout);
+
+                username_layout.setBoxStrokeColor(getResources().getColor(R.color.error_red));
+                password_layout.setBoxStrokeColor(getResources().getColor(R.color.error_red));
+
                 getUsernameEdit().requestFocus();
+        }
 
         } else {
             startAuthentication();


### PR DESCRIPTION
### Description:
Added a feature where if a user provides wrong or invalid credentials while authentication, the EditText, and the Status Bar changes its color to Red as an improved indication of error.

### Screenshot Before:
![Screenshot_2020-08-24-11-26-44-50_8f7f52555d974a92fa29728873f61978](https://user-images.githubusercontent.com/54114888/91024784-12f5f780-e616-11ea-9ea4-90f7ef276291.jpg)

### Sample Demo:
![ezgif com-video-to-gif (39)](https://user-images.githubusercontent.com/54114888/91025256-c232ce80-e616-11ea-876b-5dbd7ef4ba31.gif)