### PR TITLE
Added themed Files Sort indicator

### DIFF
--- a/src/main/java/org/amahi/anywhere/fragment/FileSortOptionsDialogFragment.java
+++ b/src/main/java/org/amahi/anywhere/fragment/FileSortOptionsDialogFragment.java
@@ -113,7 +113,7 @@ public class FileSortOptionsDialogFragment extends BottomSheetDialogFragment {
 
         Drawable dw = getResources().getDrawable(R.drawable.ic_check);
         textView.setCompoundDrawablesWithIntrinsicBounds(null, null, dw, null);
-        textView.setTextColor(getResources().getColor(R.color.primary_dark));
+        textView.setTextColor(getResources().getColor(R.color.accent));
 
     }
 

--- a/src/main/res/drawable/ic_check.xml
+++ b/src/main/res/drawable/ic_check.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="#1976D2"
+        android:fillColor="@color/accent"
         android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
 </vector>


### PR DESCRIPTION
### Description:
Added themed Files Sort indicator which changes its indication color according to light or dark theme. Currently, the indicator shows only a single type of color irrespective of the theme. This changes the color to "accent" to improve themeability.

### Dark Mode Screenshot Before:
![Screenshot_2020-08-31-04-12-54-64_8f7f52555d974a92fa29728873f61978](https://user-images.githubusercontent.com/54114888/91685086-e7738f80-eb76-11ea-806d-9700e7b573b8.jpg)

### Light Mode Screenshot Before:
![Screenshot_2020-08-31-04-13-09-36_8f7f52555d974a92fa29728873f61978](https://user-images.githubusercontent.com/54114888/91685105-f78b6f00-eb76-11ea-8c1c-6230a84603d8.jpg)

### Dark Mode Sample Demo:
![ezgif com-video-to-gif (42)](https://user-images.githubusercontent.com/54114888/91685259-797b9800-eb77-11ea-8e5c-bcc394669ba1.gif)

### Light Mode Sample Demo:
![ezgif com-video-to-gif (43)](https://user-images.githubusercontent.com/54114888/91685286-8c8e6800-eb77-11ea-8af1-38b398cf4b5f.gif)
