### PR TITLE
Added themed Scrollbar

### DIFF
--- a/src/main/res/values-notnight/colors.xml
+++ b/src/main/res/values-notnight/colors.xml
@@ -26,7 +26,7 @@
     <color name="accent">#328ce7</color>
     <color name="primary_text">#DE000000</color>
     <color name="secondary_text">#8A000000</color>
-    <color name="icons">#328ce7</color>
+    <color name="icons">#000000</color>
     <color name="divider">#757575</color>
     <color name="error_red">#ff0033</color>
     <color name="sign_in_button">#1976D2</color>

--- a/src/main/res/values-notnight/colors.xml
+++ b/src/main/res/values-notnight/colors.xml
@@ -26,7 +26,7 @@
     <color name="accent">#328ce7</color>
     <color name="primary_text">#DE000000</color>
     <color name="secondary_text">#8A000000</color>
-    <color name="icons">#000000</color>
+    <color name="icons">#328ce7</color>
     <color name="divider">#757575</color>
     <color name="error_red">#ff0033</color>
     <color name="sign_in_button">#1976D2</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -26,7 +26,7 @@
     <color name="accent">#FF9800</color>
     <color name="primary_text">#FFFFFFFF</color>
     <color name="secondary_text">#B3FFFFFF</color>
-    <color name="icons">#FF9800</color>
+    <color name="icons">#FFFFFF</color>
     <color name="divider">#757575</color>
     <color name="error_red">#ff0033</color>
     <color name="sign_in_button">#19B4F4</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -40,7 +40,7 @@
     <color name="mtrl_textinput_default_box_stroke_color" tools:override="true">@color/secondary_text</color>
 
 <!--    RecyclerView Fast Scroller-->
-    <color name="handle_color">#999999</color>
+    <color name="handle_color">@color/accent</color>
 
     <!--ATV COLORS-->
     <color name="intro_1">#0277bd</color>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -26,7 +26,7 @@
     <color name="accent">#FF9800</color>
     <color name="primary_text">#FFFFFFFF</color>
     <color name="secondary_text">#B3FFFFFF</color>
-    <color name="icons">#FFFFFF</color>
+    <color name="icons">#FF9800</color>
     <color name="divider">#757575</color>
     <color name="error_red">#ff0033</color>
     <color name="sign_in_button">#19B4F4</color>


### PR DESCRIPTION
### Description: 
Added adaptive scrollbar tint to change as per theme selected rather than being static. Sometimes, the scrollbar is barely visible in Dark Theme.

### Demo Before:
![ezgif com-video-to-gif (51)](https://user-images.githubusercontent.com/54114888/91702536-8360c380-eb96-11ea-8394-0c1e0ca4845f.gif)

### Dark Mode Demo:
![ezgif com-video-to-gif (52)](https://user-images.githubusercontent.com/54114888/91702635-a1c6bf00-eb96-11ea-8c2b-7f4915fc5f71.gif)

### Light Mode Demo:
![ezgif com-video-to-gif (53)](https://user-images.githubusercontent.com/54114888/91702687-b3a86200-eb96-11ea-9c5d-9d32f5510896.gif)
