### PR TITLE
Added Improved Files Sort Bottom Sheet

### DIFF
--- a/src/main/res/layout/filesort_options_bottom_sheet.xml
+++ b/src/main/res/layout/filesort_options_bottom_sheet.xml
@@ -18,7 +18,9 @@
             android:paddingRight="0dp"
             android:paddingBottom="4dp"
             android:text="@string/sort_by"
-            android:textSize="12sp" />
+            android:textSize="12sp"
+            android:textColor="@android:color/black"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_name_asc"
@@ -27,7 +29,8 @@
             android:padding="16dp"
             android:text="@string/file_name_a_z"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_name_des"
@@ -36,7 +39,8 @@
             android:padding="16dp"
             android:text="@string/file_name_z_a"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_time_des"
@@ -45,7 +49,8 @@
             android:padding="16dp"
             android:text="@string/date_newest"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_time_asc"
@@ -54,7 +59,8 @@
             android:padding="16dp"
             android:text="@string/date_oldest"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_size_des"
@@ -63,7 +69,8 @@
             android:padding="16dp"
             android:text="@string/size_largest"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_size_asc"
@@ -72,7 +79,8 @@
             android:padding="16dp"
             android:text="@string/size_smallest"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
         <TextView
             android:id="@+id/text_sort_type"
@@ -81,7 +89,8 @@
             android:padding="16dp"
             android:text="@string/file_type"
             android:textColor="@android:color/black"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textStyle="bold"/>
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -319,11 +319,11 @@
 
 <!--    File Options Sheet Dialog-->
     <string name="file_info">File info</string>
-    <string name="sort_by">Sort By</string>
+    <string name="sort_by">SORT BY</string>
     <string name="file_name_a_z">File name (A to Z)</string>
     <string name="file_name_z_a">File name (Z to A)</string>
-    <string name="date_newest">Date (newest first)</string>
-    <string name="date_oldest">Date (oldest first)</string>
+    <string name="date_newest">Modified (newest first)</string>
+    <string name="date_oldest">Modified (oldest first)</string>
     <string name="size_largest">Size (largest first)</string>
     <string name="size_smallest">Size (smallest first)</string>
     <string name="file_type">File Type</string>


### PR DESCRIPTION
### Feature Description:
Currently, there is a difference in Google's  Files Sorting bottom sheet and the bottom sheet used in Amahi Android App. This solves the above mentioned problem.

### Screenshot of Google's Files Sort Bottom Sheet:
![Screenshot_2020-10-01-10-27-08-82](https://user-images.githubusercontent.com/54114888/94774529-b5ef1d80-03db-11eb-870c-feecf1a270ca.jpg)

### Screenshot of Amahi Android App's Current Files Sort Bottom Sheet:
![Screenshot_2020-10-01-11-44-12-62_8f7f52555d974a92fa29728873f61978](https://user-images.githubusercontent.com/54114888/94774615-de771780-03db-11eb-9796-758705cc57e1.jpg)

### Demo of Light Theme Improved Files Sort Bottom Sheet:
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/54114888/94775302-2fd3d680-03dd-11eb-8c27-c7c8ed67b1ab.gif)

### Demo of Dark Theme Improved Files Sort Bottom Sheet:
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/54114888/94775295-2cd8e600-03dd-11eb-8a0f-40af52d49fc6.gif)

