### PR TITLE
Addition of github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,10 @@
+name: Build
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Build the app
+        run: ./gradlew build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,9 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: Install NDK
+        run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
+
       # Step 1: Assemble debug apk 
       - name: Assemble Debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,6 @@
 name: Testing Workflow
 
-# Step 1: Choose the branch or branches you want to run this workflow
-on:
-  pull_request:
-    branches:
-      - develop
+on: [pull_request, push]
 
 jobs:
   testing:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,38 @@
-name: Build
-on: [pull_request, push]
+name: Testing Workflow
+
+# Step 1: Choose the branch or branches you want to run this workflow
+on:
+  pull_request:
+    branches:
+      - develop
+
 jobs:
-  build:
+  testing:
+    name: Lint Check and Testing
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout the code
-        uses: actions/checkout@v2
-      - name: Build the app
-        run: ./gradlew build
+      - name: Clone Repo
+        uses: actions/checkout@v1
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      # Step 3: Check the code with Android linter
+      - name: Run Android Linter
+        run: ./gradlew lintStagingDebug
+
+      # Step 4: Run your unit tests
+      - name: Run Unit Tests
+        run: ./gradlew testStagingDebugUnitTest
+
+      # Step 4: Assemble debug apk 
+      - name: Assemble Debug APK
+        run: ./gradlew assembleStagingDebug
+
+      # Step 4: Assemble debug test apk
+      - name: Assemble Debug Test APK
+        run: ./gradlew assembleStagingDebugAndroidTest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Assemble Debug APK
         run: ./gradlew assembleDebug
 
+      # TODO: Connect Virtual Device and Run Tests 
       # Step 2: Assemble debug test apk
-      - name: Assemble Debug Test APK
-        run: ./gradlew connectedDebugAndroidTest
+      # - name: Assemble Debug Test APK
+      #   run: ./gradlew connectedDebugAndroidTest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 
 jobs:
   testing:
-    name: Lint Check and Testing
+    name: Testing
 
     runs-on: ubuntu-latest
 
@@ -17,18 +17,10 @@ jobs:
         with:
           java-version: 1.8
 
-      # Step 3: Check the code with Android linter
-      - name: Run Android Linter
-        run: ./gradlew lintStagingDebug
-
-      # Step 4: Run your unit tests
-      - name: Run Unit Tests
-        run: ./gradlew testStagingDebugUnitTest
-
-      # Step 4: Assemble debug apk 
+      # Step 1: Assemble debug apk 
       - name: Assemble Debug APK
-        run: ./gradlew assembleStagingDebug
+        run: ./gradlew assembleDebug
 
-      # Step 4: Assemble debug test apk
+      # Step 2: Assemble debug test apk
       - name: Assemble Debug Test APK
-        run: ./gradlew assembleStagingDebugAndroidTest
+        run: ./gradlew connectedDebugAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_script:
     - adb shell input keyevent 82 &
 
 script:
-    - ./gradlew assembleDebug
     - ./gradlew connectedDebugAndroidTest
 
 notifications:


### PR DESCRIPTION
Fixes #717 
I have been able to run `assembleDebug` on github actions but due to some issue of virtual device, I am not able to run `assembleDebugAndroidTest` on github actions.
Nevertheless, in this PR, I am running `assembleDebug` on github actions and `assembleDebugAndroidTest` on Travis which reduces the time it takes to run the tests. 
In future, we can move `assembleDebugAndroidTest` to github actions too and completely remove the dependency on Travis.  
