### PR TITLE
GitHub action for merge conflict notification

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Testing Workflow
+name: Build Test
 
 on: [pull_request, push]
 

--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -1,0 +1,28 @@
+name: Conflict Test
+
+on:
+  push:
+    branches: [ master, beta ]
+  pull_request:
+    types: [synchronize]
+    branches: [ master, beta ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check if PR contains merge conflict issue
+      uses: eps1lon/actions-label-merge-conflict@releases/2.x
+      if: env.LABELING_TOKEN != '' && env.LABELING_TOKEN != null
+      id: check
+      with:
+        dirtyLabel: "conflicting"
+        repoToken: "${{ secrets.GITHUB_TOKEN  }}"
+        continueOnMissingPermissions: true
+        commentOnDirty: 'This pull request has conflicting changes, the author must resolve the conflicts before this pull request can be merged.'
+        commentOnClean: 'Conflicts have been resolved. A maintainer will take a look shortly.'
+      env:
+        LABELING_TOKEN: ${{secrets.GITHUB_TOKEN }}
+
+# Credits: https://baywet.github.io/pull-request-conflict-github-workflow/

--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -24,5 +24,3 @@ jobs:
         commentOnClean: 'Conflicts have been resolved. A maintainer will take a look shortly.'
       env:
         LABELING_TOKEN: ${{secrets.GITHUB_TOKEN }}
-
-# Credits: https://baywet.github.io/pull-request-conflict-github-workflow/


### PR DESCRIPTION
Currently, there's no notification for the developer/maintainer whenever there's a merge conflict in a PR.

Using this GitHub action, whenever there's a merge conflict in a PR due to some changes in the development tree, the PR will be labelled as "conflicting" and the action will post a comment on the PR saying that the conflict must be resolved.

Ref: https://baywet.github.io/pull-request-conflict-github-workflow/